### PR TITLE
namechange of Headphones.py also in init.d

### DIFF
--- a/headphonesinit.d
+++ b/headphonesinit.d
@@ -18,7 +18,7 @@ APP_PATH=/usr/local/sbin/headphones
 DAEMON=/usr/bin/python
 
 # startup args
-DAEMON_OPTS="headphones.py -q"
+DAEMON_OPTS="Headphones.py -q"
 
 # script name
 NAME=headphones


### PR DESCRIPTION
I noticed headphones wouldn't autostart anymore, and discovered you changed the filename of headphones.py
