### PR TITLE
fix for init.d 

### DIFF
--- a/headphonesinit.d
+++ b/headphonesinit.d
@@ -18,7 +18,7 @@ APP_PATH=/usr/local/sbin/headphones
 DAEMON=/usr/bin/python
 
 # startup args
-DAEMON_OPTS="Headphones.py -q"
+DAEMON_OPTS=" Headphones.py -q"
 
 # script name
 NAME=headphones


### PR DESCRIPTION
Forgot a space when renaming, which broke the autostart
