### PR TITLE
Solaris SMF Manifest

### DIFF
--- a/headphones.xml
+++ b/headphones.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0"?>
+<!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
+<!--
+        Created by Manifold
+--><service_bundle type="manifest" name="headphones">
+
+    <service name="application/headphones" type="service" version="1">
+
+        <create_default_instance enabled="true"/>
+        
+        <single_instance/>
+
+        <dependency name="network" grouping="require_all" restart_on="error" type="service">
+            <service_fmri value="svc:/milestone/network:default"/>
+        </dependency>
+
+        <dependency name="filesystem" grouping="require_all" restart_on="error" type="service">
+            <service_fmri value="svc:/system/filesystem/local"/>
+        </dependency>
+
+        <method_context>
+            <method_credential user="sabnzbd" group="sabnzbd"/>
+        </method_context>
+
+        <exec_method type="method" name="start" exec="python /opt/headphones/Headphones.py -d" timeout_seconds="60"/>
+
+        <exec_method type="method" name="stop" exec=":kill" timeout_seconds="60"/>
+
+        <property_group name="startd" type="framework">
+            <propval name="duration" type="astring" value="contract"/>
+            <propval name="ignore_error" type="astring" value="core,signal"/>
+        </property_group>
+      
+        
+        <stability value="Evolving"/>
+
+        <template>
+            <common_name>
+                <loctext xml:lang="C">
+                    Headphones
+                </loctext>
+            </common_name>
+        </template>
+
+    </service>
+
+</service_bundle>


### PR DESCRIPTION
I created a quick Solaris SMF manifest for anyone who wants to run Headphones as a service on solaris, they just need to edit the user and group to run headphones. I assume they have it installed in /opt/Headphones.

Thanks for the great work!
