### PR TITLE
Added unused "new" to unqueueAlbum definition

### DIFF
--- a/headphones/webserve.py
+++ b/headphones/webserve.py
@@ -163,7 +163,7 @@ class WebInterface(object):
 			raise cherrypy.HTTPRedirect(redirect)
 	queueAlbum.exposed = True
 
-	def unqueueAlbum(self, AlbumID, ArtistID):
+	def unqueueAlbum(self, AlbumID, ArtistID, new):
 		logger.info(u"Marking album: " + AlbumID + "as skipped...")
 		myDB = db.DBConnection()
 		controlValueDict = {'AlbumID': AlbumID}


### PR DESCRIPTION
Hitting "mark as skipped" in the web ui was throwing an error without it.
