### PR TITLE
Fix for post-processor thread dying silently

### DIFF
--- a/headphones/webserve.py
+++ b/headphones/webserve.py
@@ -163,7 +163,7 @@ class WebInterface(object):
 			raise cherrypy.HTTPRedirect(redirect)
 	queueAlbum.exposed = True
 
-	def unqueueAlbum(self, AlbumID, ArtistID, new):
+	def unqueueAlbum(self, AlbumID, ArtistID):
 		logger.info(u"Marking album: " + AlbumID + "as skipped...")
 		myDB = db.DBConnection()
 		controlValueDict = {'AlbumID': AlbumID}


### PR DESCRIPTION
When the post-process thread tried to import a file into a beets Item that mutagen couldn't parse it would kill the thread silently. The auto-post-process would just keep dying on the same file every 5 minutes. This just adds a try block so the thread can continue. Also some other error reporting.

The post-processor doesn't seem to mark the unreadable releases as failed or unprocessed. You might want to change that.

I keep pulling from upstream/develop (your develop branch) and merging and it still wants to add these phantom commits that you already took. No idea why - the "files changed" is just 1 and only shows what is actually changed.
