### PR TITLE
With a large database, headphones becomes unusable on an iphone over 3g a

### DIFF
--- a/headphones/__init__.py
+++ b/headphones/__init__.py
@@ -497,6 +497,8 @@ def dbcheck():
     c.execute('CREATE TABLE IF NOT EXISTS lastfmcloud (ArtistName TEXT, ArtistID TEXT, Count INTEGER)')
     c.execute('CREATE TABLE IF NOT EXISTS descriptions (ReleaseGroupID TEXT, ReleaseID TEXT, Summary TEXT, Content TEXT)')
     c.execute('CREATE TABLE IF NOT EXISTS releases (ReleaseID TEXT, ReleaseGroupID TEXT, UNIQUE(ReleaseID, ReleaseGroupID))')
+    c.execute('CREATE INDEX IF NOT EXISTS tracks_albumid ON tracks(AlbumID ASC)')
+    c.execute('CREATE INDEX IF NOT EXISTS album_artistid_reldate ON albums(ArtistID ASC, ReleaseDate DESC)')
     
     try:
         c.execute('SELECT IncludeExtras from artists')


### PR DESCRIPTION
With a large database, headphones becomes unusable on an iphone over 3g as there is too much data being processed before safari times out. Even when running at home on wifi on a proper computer, performance is unacceptable.
Have added a couple of indexes to the INIT script based on the queries running in webserve. These have been tested on my home NAS and make a significant difference to usability i.e. I can actually access larger artist pages over 3G using my iphone.
