### PR TITLE
Need to lower() the files to ensure .MP3 and .Mp3 are picked up as valid 

### DIFF
--- a/headphones/postprocessor.py
+++ b/headphones/postprocessor.py
@@ -118,7 +118,7 @@ def verify(albumid, albumpath):
 	
 	for r,d,f in os.walk(albumpath):
 		for files in f:
-			if any(files.endswith('.' + x) for x in headphones.MEDIA_FORMATS):
+			if any(files.lower().endswith('.' + x.lower()) for x in headphones.MEDIA_FORMATS):
 				downloaded_track_list.append(os.path.join(r, files))	
 	
 	# test #1: metadata - usually works
@@ -278,7 +278,7 @@ def cleanupFiles(albumpath):
 	logger.info('Cleaning up files')
 	for r,d,f in os.walk(albumpath):
 		for files in f:
-			if not any(files.endswith('.' + x) for x in headphones.MEDIA_FORMATS):
+			if not any(files.lower().endswith('.' + x.lower()) for x in headphones.MEDIA_FORMATS):
 				logger.debug('Removing: %s' % files)
 				try:
 					os.remove(os.path.join(r, files))
@@ -473,7 +473,7 @@ def updateHave(albumpath):
 	
 	for r,d,f in os.walk(albumpath):
 		for files in f:
-			if any(files.endswith('.' + x) for x in headphones.MEDIA_FORMATS):
+			if any(files.lower().endswith('.' + x.lower()) for x in headphones.MEDIA_FORMATS):
 				results.append(os.path.join(r, files))
 	
 	if results:


### PR DESCRIPTION
Need to lower() the files to ensure .MP3 and .Mp3 are picked up as valid suffixes during post processing. Have noticed this being done elsewhere but not in the postprocess script...
