### PR TITLE
Sending to SABnzbd doesn't work if SAB_HOST ends with a slash

### DIFF
--- a/headphones/sab.py
+++ b/headphones/sab.py
@@ -67,6 +67,9 @@ def sendNZB(nzb):
 
     if not headphones.SAB_HOST.startswith('http'):
     	headphones.SAB_HOST = 'http://' + headphones.SAB_HOST
+
+    if headphones.SAB_HOST.endswith('/'):
+        headphones.SAB_HOST = headphones.SAB_HOST[0:len(headphones.SAB_HOST)-1]
     
     url = headphones.SAB_HOST + "/" + "api?" + urllib.urlencode(params)
 


### PR DESCRIPTION
I just hit this minor bug. I think handling it behind the scenes improves user experience.
