### PR TITLE
Check for None when requesting an artist page

### DIFF
--- a/headphones/webserve.py
+++ b/headphones/webserve.py
@@ -44,6 +44,8 @@ class WebInterface(object):
 		myDB = db.DBConnection()
 		artist = myDB.action('SELECT * FROM artists WHERE ArtistID=?', [ArtistID]).fetchone()
 		albums = myDB.select('SELECT * from albums WHERE ArtistID=? order by ReleaseDate DESC', [ArtistID])
+		if artist is None:
+			raise cherrypy.HTTPRedirect("home")
 		return serve_template(templatename="artist.html", title=artist['ArtistName'], artist=artist, albums=albums)
 	artistPage.exposed = True
 	


### PR DESCRIPTION
Without this check, an artist that doesn't exist in the database results in a stack trace.

A better solution would be to use correct HTTP status codes, etc, but Headphones doesn't do that anywhere yet.
