### PR TITLE
Torrent file save file open correction

### DIFF
--- a/headphones/searcher.py
+++ b/headphones/searcher.py
@@ -868,7 +868,7 @@ def searchTorrent(albumid=None, new=False):
                     torrent_name = torrent_folder_name + '.torrent'
                     download_path = os.path.join(headphones.TORRENTBLACKHOLE_DIR, torrent_name)
                     try:
-                        f = open(download_path, 'w')
+                        f = open(download_path, 'wb')
                         f.write(data)
                         f.close()
                         logger.info('File saved to: %s' % torrent_name)


### PR DESCRIPTION
If the file open is "w" only instead of "wb" the file written is not binary identical to the original which cause torrent software to not accept the file.
