### PR TITLE
Problem when torrent does not contain either mp3 or flac files.

### DIFF
--- a/headphones/searcher.py
+++ b/headphones/searcher.py
@@ -660,7 +660,7 @@ def searchTorrent(albumid=None, new=False):
                                                                             torrent = f.read()
                                                                         else:
                                                                             torrent = response.read()
-									if int(torrent.find(".mp3")) > 0 and int(torrent.find(".flac")) < 1:
+									if int(torrent.find(".flac")) < 1:
 										rightformat = False
 							except Exception, e:
 								rightformat = False
@@ -733,7 +733,7 @@ def searchTorrent(albumid=None, new=False):
                                                                             torrent = f.read()
                                                                         else:
                                                                             torrent = response.read()
-									if int(torrent.find(".mp3")) > 0 and int(torrent.find(".flac")) < 1:
+									if int(torrent.find(".flac")) < 1:
 										rightformat = False
 							except Exception, e:
 								rightformat = False
@@ -800,7 +800,7 @@ def searchTorrent(albumid=None, new=False):
                                                                             torrent = f.read()
                                                                         else:
                                                                             torrent = response.read()
-									if int(torrent.find(".mp3")) > 0 and int(torrent.find(".flac")) < 1:
+									if int(torrent.find(".flac")) < 1:
 										rightformat = False
 							except Exception, e:
 								rightformat = False


### PR DESCRIPTION
A little logic problem when we are setup as FLAC only. If the torrent contained no mp3 nor flac files is was being accepted, this change correct that behavior. 

It will accept any torrent that has flac file in it, even if it also have mp3, at least there are flac in it. I was getting stuff with rar in the torrent and the would probably have contained the mp3 judging at the size of the torrent HP found.
