### PR TITLE
Provides: acts as a name that other scripts can call.

### DIFF
--- a/init.ubuntu
+++ b/init.ubuntu
@@ -1,9 +1,11 @@
 #! /bin/sh
 
 ### BEGIN INIT INFO
-# Provides:          Headphones application instance
-# Required-Start:    $all
-# Required-Stop:     $all
+# Provides:          headphones
+# Required-Start:    $local_fs $network $remote_fs
+# Required-Stop:     $local_fs $network $remote_fs
+# Should-Start:      $NetworkManager
+# Should-Stop:       $NetworkManager
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6
 # Short-Description: starts instance of Headphones


### PR DESCRIPTION
Required-Start/Stop: $all means it should start last. Having this in multiple scripts (Sick Beard, Couch Potato, etc) can cause a loop. Changed this to match JCFP's SABnzbd+ start-up script.
Should-Start/Stop: Changed this to match JCFP's SABnzbd+ start-up script.
