### PR TITLE
Bug fixed, database still bad

### DIFF
--- a/headphones/mb.py
+++ b/headphones/mb.py
@@ -281,6 +281,13 @@ def getReleaseGroup(rgid):
             if not releaseResult:
                 continue
             
+            #skip releases that do not have any release date associated with them
+            #if we don't do this the albums will get the release date "None" and will
+            #automatically be set to wanted if "Automatically Mark Upcoming Albums as Wanted" is set
+            #because None is not a valid date and will never be in the past so it is always upcoming
+            if 'date' not in releaseResult:
+                continue       
+
             if releaseGroup['type'] == 'live' and releaseResult['status'] != 'Official':
                     logger.debug('%s is not an official live album. Skipping' % releaseResult.name)
                     continue


### PR DESCRIPTION
For some reason the releases without any release date stick around even after refreshing the artist.
Deleting the artist and adding him again works fine but is annoying and stupid.

I tried automating the deletion of the corrupted rows with the code below but still couldn't get it to work

``` python
            myDB = db.DBConnection()
            deletion = myDB.action('DELETE FROM albums WHERE ReleaseDate="NONE"')
            fixArtists = myDB.action('UPDATE artists SET ReleaseDate="",LatestAlbum="",AlbumID="" WHERE ReleaseDate="None"')
            logger.info("deleted releases without a date")       
```
