### PR TITLE
Init file for systemd-based platforms such as RedHat Fedora / RHEL, and CentOS

### DIFF
--- a/init.fedora.centos.systemd
+++ b/init.fedora.centos.systemd
@@ -1,0 +1,66 @@
+# Headphones - Automatic music downloader for SABnzbd
+#
+# Service Unit file for systemd system manager
+#
+# INSTALLATION NOTES
+#
+#	1. Rename this file as you want, ensuring that it ends in .service
+#		e.g. 'headphones.service'
+#
+#	2. Adjust configuration settings as required.  More details in the
+#	   "CONFIGURATION NOTES" section shown below.
+#
+#	3. Copy this file into your systemd service unit directory, which is
+#	   often '/lib/systemd/system'.
+#
+#	4. Create any files/directories that you specified back in step #2.
+#		e.g. '/etc/headphones/headphones.ini'
+#			 '/home/sabnzbd/.headphones'
+#
+#	5. Enable boot-time autostart with the following commands:
+#		systemctl daemon-reload
+#		systemctl enable headphones.service
+#
+#	6. Start now with the following command:
+#		systemctl start headphones.service
+#
+#   7. If troubleshooting startup-errors, start by checking permissions
+#      and ownership on the files/directories that you created in step #4.
+#
+#
+# CONFIGURATION NOTES
+#
+#	 - The example settings in this file assume that:
+#		1. You will run Headphones as user/group: sabnzbd.sabnzbd
+#		2. You will either have Headphones installed as a subdirectory
+#		   under '~sabnzbd', or that you will have a symlink under
+#		   '~/sabnzbd' pointing to your Headphones install dir.
+#	    3. Your Headphones data directory and configuration file will be
+#		   in separate locations from your Headphones install dir, to
+#		   simplify updates.
+#			
+#    - Option names (e.g. ExecStart=, Type=) appear to be case-sensitive)
+#
+#    - Adjust ExecStart= to point to:
+# 		1. Your Headphones executable,
+# 		2. Your config file (recommended is to put it somewhere in /etc)
+#       3. Your datadir (recommended is to NOT put it in your Headphones exec dir)
+#
+#    - Adjust User= and Group= to the user/group you want Headphones to run as.
+#
+#    - WantedBy= specifies which target (i.e. runlevel) to start Headphones for.
+#        multi-user.target equates to runlevel 3 (multi-user text mode)
+#        graphical.target  equates to runlevel 5 (multi-user X11 graphical mode)
+
+[Unit]
+Description=Headphones - Automatic music downloader for SABnzbd
+
+[Service]
+ExecStart=/home/sabnzbd/headphones/Headphones.py --daemon --config /etc/headphones/headphones.ini --datadir /home/sabnzbd/.headphones --nolaunch --quiet
+GuessMainPID=no
+Type=forking
+User=sabnzbd
+Group=sabnzbd
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
I noticed that Headphones has a variety of init scripts, but doesn't seem to have one for systemd-based platforms such as RedHat Fedora / RHEL, and CentOS.

I put one together, and have tested it for proper startup / shutdown operation on Fedora 17.  It should be equally useful for earlier Fedora versions (back to F15), as well as for RHEL 6.x and CentOS 6.x.

The file is heavily self-documented, and is relatively simple to customize and use.

Hope this helps increase Headphones' usage out there on more platforms!

Cheers

jnikolich
