### PR TITLE
Kick Ass Torrents fix (no more invalid bencoding)

### DIFF
--- a/headphones/searcher.py
+++ b/headphones/searcher.py
@@ -643,6 +643,7 @@ def searchTorrent(albumid=None, new=False, losslessOnly=False):
 								if format == "2":
                                                                         request = urllib2.Request(url)
                                                                         request.add_header('Accept-encoding', 'gzip')
+                                                                        request.add_header('Referer', 'http://kat.ph/')
                                                                         response = urllib2.urlopen(request)
                                                                         if response.info().get('Content-Encoding') == 'gzip':
                                                                             buf = StringIO( response.read())


### PR DESCRIPTION
Kat.ph torrents didn't work for me so I modified the searcher.py file. I found out that without a referer it wouldn't get the .torrent but a torcache html file instead.

Might not be the best solution, I'm new to python so I just did whatever works.
