### PR TITLE
Synoindex fixes

### DIFF
--- a/headphones/notifiers.py
+++ b/headphones/notifiers.py
@@ -197,6 +197,8 @@ class Synoindex:
         return os.path.exists(self.util_loc)
 
     def notify(self, path):
+        path = os.path.abspath(path)
+
         if not self.util_exists():
             logger.warn("Error sending notification: synoindex utility not found at %s" % self.util_loc)
             return
@@ -209,12 +211,12 @@ class Synoindex:
             logger.warn("Error sending notification: Path passed to synoindex was not a file or folder.")
             return
 
-        cmd = [self.util_loc, cmd_arg, '\"%s\"' % os.path.abspath(path)]
-        logger.debug("Calling synoindex command: %s" % str(cmd))
+        cmd = [self.util_loc, cmd_arg, path]
+        logger.info("Calling synoindex command: %s" % str(cmd))
         try:
             p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, cwd=headphones.PROG_DIR)
             out, error = p.communicate()
-            logger.debug("Synoindex result: %s" % str(out))
+            #synoindex never returns any codes other than '0', highly irritating
         except OSError, e:
             logger.warn("Error sending notification: %s" % str(e))
 


### PR DESCRIPTION
Fixed a path issue that was causing synology index notifications to not work properly. Now synology notifications are logged to info instead of debug, as well.
