### PR TITLE
Header-based HTTPS Redirect

### DIFF
--- a/headphones/webserve.py
+++ b/headphones/webserve.py
@@ -25,7 +25,7 @@ import threading
 
 import headphones
 
-from headphones import logger, searcher, db, importer, mb, lastfm, librarysync, webfilters
+from headphones import logger, searcher, db, importer, mb, lastfm, librarysync
 from headphones.helpers import checked, radio
 
 import lib.simplejson as simplejson
@@ -46,9 +46,7 @@ def serve_template(templatename, **kwargs):
         return exceptions.html_error_template().render()
     
 class WebInterface(object):
-
-    _cp_filters = [webfilters.HTTPSFilter()]
-
+    
     def index(self):
         raise cherrypy.HTTPRedirect("home")
     index.exposed=True


### PR DESCRIPTION
Refs Issue #749

This change allows CherryPy to redirect using the appropriate scheme (http/https) based on information a proxying webserver can add to the request header.

Turns out CherryPy has a built-in tool for handling this situation. `cherrypy.tools.proxy` pays attention to either `X-Forwarded-Ssl: on` or `X-Forwarded-Proto: https` in the request header. An Apache proxy config setting that header would look like:

``` apache
RequestHeader add X-Forwarded-Proto https
```

A lot of overhead for a one-line change. Initally seemed like more code would be required.
