### PR TITLE
New Feature - Exclude Skipped Albums In Total Artist Track Count

### DIFF
--- a/data/interfaces/brink/config.html
+++ b/data/interfaces/brink/config.html
@@ -508,6 +508,15 @@
 								<input type="text" name="log_dir" value="${config['log_dir']}" size="40" />
 							</td>
 						</tr><!--end Logs-->
+						<tr>
+							<td>
+								<label for="log_dir">Exclude Skipped Albums from Artist Have Count:</label>
+							</td>
+							<td>
+							<input type="checkbox" name="excludeskippedintotal" value="1" ${config['excludeskippedintotal']} />
+							<label for="excludeskippedintotal">Exclude Skipped From Have Count</label>
+							</td>
+						</tr>
 					</table>
 				</div><!--end Miscellaneous-->
 				

--- a/data/interfaces/classic/config.html
+++ b/data/interfaces/classic/config.html
@@ -328,6 +328,7 @@
                       	<i class="smalltext">(EPs, Compilations, Live Albums, Remix Albums and Singles)</i>
 						<h3><input type="checkbox" name="autowant_upcoming" value="1" ${config['autowant_upcoming']} />Automatically Mark Upcoming Albums as Wanted</h3>	
 						<h3><input type="checkbox" name="autowant_all" value="1" ${config['autowant_all']} />Automatically Mark All Albums as Wanted</h3>
+						<h3><input type="checkbox" name="excludeskippedintotal" value="1" ${config['excludeskippedintotal']} />Exclude Skipped Albums from Artist Have Count</h3>
 						<br>
 						<h3>Interface: <select name="interface"><h3>
 						%for interface in config['interface_list']:

--- a/data/interfaces/default/config.html
+++ b/data/interfaces/default/config.html
@@ -502,6 +502,9 @@ m<%inherit file="base.html"/>
 		        			<div class="row leftcheckbox">
 		        				<input type="checkbox" name="autowant_all" value="1" ${config['autowant_all']} /><label>Automatically Mark All Albums as Wanted</label>
 		        			</div>
+							<div class="checkbox left row">
+		        		  	<input type="checkbox" name="excludeskippedintotal" value="1" ${config['excludeskippedintotal']} /><label>Exclude Skipped Albums In Total in Have Counts</label>
+							</div>
 		        		</div>                		
 		        	</fieldset>
 					<fieldset>

--- a/data/interfaces/remix/config.html
+++ b/data/interfaces/remix/config.html
@@ -328,6 +328,7 @@
                       	<i class="smalltext">(EPs, Compilations, Live Albums, Remix Albums and Singles)</i>
 						<h3><input type="checkbox" name="autowant_upcoming" value="1" ${config['autowant_upcoming']} />Automatically Mark Upcoming Albums as Wanted</h3>	
 						<h3><input type="checkbox" name="autowant_all" value="1" ${config['autowant_all']} />Automatically Mark All Albums as Wanted</h3>
+						<h3><input type="checkbox" name="excludeskippedintotal" value="1" ${config['excludeskippedintotal']} />Exclude Skipped Albums from Artist Have Count</h3>
 						<br>
 						<h3>Interface: <select name="interface"><h3>
 						%for interface in config['interface_list']:

--- a/headphones/__init__.py
+++ b/headphones/__init__.py
@@ -104,6 +104,7 @@ USENET_RETENTION = None
 INCLUDE_EXTRAS = False
 AUTOWANT_UPCOMING = False
 AUTOWANT_ALL = False
+EXCLUDESKIPPEDINTOTAL = False
 
 SEARCH_INTERVAL = 360
 LIBRARYSCAN_INTERVAL = 300
@@ -238,7 +239,7 @@ def initialize():
         global __INITIALIZED__, FULL_PATH, PROG_DIR, VERBOSE, DAEMON, DATA_DIR, CONFIG_FILE, CFG, CONFIG_VERSION, LOG_DIR, CACHE_DIR, \
                 HTTP_PORT, HTTP_HOST, HTTP_USERNAME, HTTP_PASSWORD, HTTP_ROOT, LAUNCH_BROWSER, API_ENABLED, API_KEY, GIT_PATH, \
                 CURRENT_VERSION, LATEST_VERSION, CHECK_GITHUB, CHECK_GITHUB_ON_STARTUP, CHECK_GITHUB_INTERVAL, MUSIC_DIR, DESTINATION_DIR, PREFERRED_QUALITY, PREFERRED_BITRATE, DETECT_BITRATE, \
-                ADD_ARTISTS, CORRECT_METADATA, MOVE_FILES, RENAME_FILES, FOLDER_FORMAT, FILE_FORMAT, CLEANUP_FILES, INCLUDE_EXTRAS, AUTOWANT_UPCOMING, AUTOWANT_ALL, \
+                ADD_ARTISTS, CORRECT_METADATA, MOVE_FILES, RENAME_FILES, FOLDER_FORMAT, FILE_FORMAT, CLEANUP_FILES, INCLUDE_EXTRAS, AUTOWANT_UPCOMING, AUTOWANT_ALL, EXCLUDESKIPPEDINTOTAL, \
                 ADD_ALBUM_ART, EMBED_ALBUM_ART, EMBED_LYRICS, DOWNLOAD_DIR, BLACKHOLE, BLACKHOLE_DIR, USENET_RETENTION, SEARCH_INTERVAL, \
                 TORRENTBLACKHOLE_DIR, NUMBEROFSEEDERS, ISOHUNT, KAT, MININOVA, WAFFLES, WAFFLES_UID, WAFFLES_PASSKEY, DOWNLOAD_TORRENT_DIR, \
                 LIBRARYSCAN_INTERVAL, DOWNLOAD_SCAN_INTERVAL, SAB_HOST, SAB_USERNAME, SAB_PASSWORD, SAB_APIKEY, SAB_CATEGORY, \
@@ -313,6 +314,7 @@ def initialize():
         INCLUDE_EXTRAS = bool(check_setting_int(CFG, 'General', 'include_extras', 0))
         AUTOWANT_UPCOMING = bool(check_setting_int(CFG, 'General', 'autowant_upcoming', 1))
         AUTOWANT_ALL = bool(check_setting_int(CFG, 'General', 'autowant_all', 0))
+        EXCLUDESKIPPEDINTOTAL = bool(check_setting_int(CFG, 'General', 'excludeskippedintotal', 0))
         
         SEARCH_INTERVAL = check_setting_int(CFG, 'General', 'search_interval', 360)
         LIBRARYSCAN_INTERVAL = check_setting_int(CFG, 'General', 'libraryscan_interval', 300)
@@ -587,6 +589,7 @@ def config_write():
     new_config['General']['include_extras'] = int(INCLUDE_EXTRAS)
     new_config['General']['autowant_upcoming'] = int(AUTOWANT_UPCOMING)
     new_config['General']['autowant_all'] = int(AUTOWANT_ALL)
+    new_config['General']['excludeskippedintotal'] =int(EXCLUDESKIPPEDINTOTAL)
     
     new_config['General']['numberofseeders'] = NUMBEROFSEEDERS
     new_config['General']['torrentblackhole_dir'] = TORRENTBLACKHOLE_DIR

--- a/headphones/importer.py
+++ b/headphones/importer.py
@@ -412,3 +412,10 @@ def updateFormat():
             newValueDict = {"Format": f.format}
             myDB.upsert("have", newValueDict, controlValueDict)
         logger.info('Finished finding media format for %s files' % len(havetracks))
+        
+def updateArtistTotalTracks(artistid):
+    if headphones.EXCLUDESKIPPEDINTOTAL:
+      myDB = db.DBConnection()
+      totaltracksNotIgnored = len(myDB.select('SELECT tracks.ArtistID from tracks INNER JOIN albums ON tracks.AlbumID = albums.AlbumID WHERE albums.Status <> ? AND albums.ArtistId=?', ['Skipped', artistid]))
+      myDB.action('UPDATE artists SET TotalTracks=? WHERE ArtistID=?', [totaltracksNotIgnored, artistid])
+      logger.info(u"Updating Total Tracks Complete for: " + artistid)

--- a/headphones/updater.py
+++ b/headphones/updater.py
@@ -29,5 +29,6 @@ def dbUpdate():
     
         artistid = artist[0]
         importer.addArtisttoDB(artistid)
+        importer.updateArtistTotalTracks(artistid)
         
     logger.info('Update complete')

--- a/headphones/webserve.py
+++ b/headphones/webserve.py
@@ -420,6 +420,7 @@ class WebInterface(object):
                     "include_extras" : checked(headphones.INCLUDE_EXTRAS),
                     "autowant_upcoming" : checked(headphones.AUTOWANT_UPCOMING),
                     "autowant_all" : checked(headphones.AUTOWANT_ALL),
+                    "excludeskippedintotal" : checked(headphones.EXCLUDESKIPPEDINTOTAL),
                     "log_dir" : headphones.LOG_DIR,
                     "interface_list" : interface_list,
                     "music_encoder":        checked(headphones.MUSIC_ENCODER),
@@ -463,7 +464,7 @@ class WebInterface(object):
         usenet_retention=None, nzbmatrix=0, nzbmatrix_username=None, nzbmatrix_apikey=None, newznab=0, newznab_host=None, newznab_apikey=None, newznab_enabled=0,
         nzbsorg=0, nzbsorg_uid=None, nzbsorg_hash=None, newzbin=0, newzbin_uid=None, newzbin_password=None, preferred_quality=0, preferred_bitrate=None, detect_bitrate=0, move_files=0, 
         torrentblackhole_dir=None, download_torrent_dir=None, numberofseeders=10, use_isohunt=0, use_kat=0, use_mininova=0, waffles=0, waffles_uid=None, waffles_passkey=None,
-        rename_files=0, correct_metadata=0, cleanup_files=0, add_album_art=0, embed_album_art=0, embed_lyrics=0, destination_dir=None, folder_format=None, file_format=None, include_extras=0, autowant_upcoming=False, autowant_all=False, interface=None, log_dir=None,
+        rename_files=0, correct_metadata=0, cleanup_files=0, add_album_art=0, embed_album_art=0, embed_lyrics=0, destination_dir=None, folder_format=None, file_format=None, include_extras=0, autowant_upcoming=False, autowant_all=False, excludeskippedintotal=False, interface=None, log_dir=None,
         music_encoder=0, encoder=None, bitrate=None, samplingfrequency=None, encoderfolder=None, advancedencoder=None, encoderoutputformat=None, encodervbrcbr=None, encoderquality=None, encoderlossless=0,
         prowl_enabled=0, prowl_onsnatch=0, prowl_keys=None, prowl_priority=0, xbmc_enabled=0, xbmc_host=None, xbmc_username=None, xbmc_password=None, xbmc_update=0, xbmc_notify=0, 
         nma_enabled=False, nma_apikey=None, nma_priority=0, synoindex_enabled=False, mirror=None, customhost=None, customport=None, customsleep=None, hpuser=None, hppass=None, **kwargs):
@@ -525,6 +526,7 @@ class WebInterface(object):
         headphones.INCLUDE_EXTRAS = include_extras
         headphones.AUTOWANT_UPCOMING = autowant_upcoming
         headphones.AUTOWANT_ALL = autowant_all
+        headphones.EXCLUDESKIPPEDINTOTAL = excludeskippedintotal
         headphones.INTERFACE = interface
         headphones.LOG_DIR = log_dir
         headphones.MUSIC_ENCODER = music_encoder


### PR DESCRIPTION
Added a new option to the configuration page called "Exclude Skipped
Albums In Total in Have Counts". When ticked, the total "Have" count for
an artist will only include albums marked as Downloaded or Wanted.

The totaltracks for the artist will not include skipped albums.

A "Force Update Active Artists" is required when the artist already
exists in the headphones database.

The Windows GitHub has screwed up my "Files Changed" so it looks crap from my end (was fine inside the client). Hopefully the merge will be ok though.
