### PR TITLE
Resolve library import edge case

### DIFF
--- a/headphones/importer.py
+++ b/headphones/importer.py
@@ -41,7 +41,7 @@ def artistlist_to_mbids(artistlist, forced=False):
 
     for artist in artistlist:
         
-        if not artist:
+        if not artist and not (artist == ' '):
             continue
             
         results = mb.findArtist(artist, limit=1)


### PR DESCRIPTION
When adding a library, it is possible the single space character (' ') is added as an artist. The Musicbrainz function _do_mb_search is not capable of handling this, and throws a ValueError, as no query is provided. This checks if an artist fits this situation, and continues with the next possible artist.
