### PR TITLE
allow setting custom cache_dir

### DIFF
--- a/data/interfaces/brink/config.html
+++ b/data/interfaces/brink/config.html
@@ -559,6 +559,15 @@
 								<input type="text" name="log_dir" value="${config['log_dir']}" size="40" />
 							</td>
 						</tr><!--end Logs-->
+						<!--Cache-->
+						<tr>
+							<td>
+								<label for="cache_dir">Cache Directory:</label>
+							</td>
+							<td>
+								<input type="text" name="cache_dir" value="${config['cache_dir']}" size="40" />
+							</td>
+						</tr><!--end Cache-->
 					</table>
 				</div><!--end Miscellaneous-->
 				

--- a/data/interfaces/classic/config.html
+++ b/data/interfaces/classic/config.html
@@ -342,6 +342,8 @@
 						</select>
 						<br><br>
                     	<h3>Log Directory:</h3><input type="text" name="log_dir" value="${config['log_dir']}" size="50">
+						<br><br>
+                    	<h3>Cache Directory:</h3><input type="text" name="cache_dir" value="${config['cache_dir']}" size="50">
                 </td>
             </tr>
             <tr>

--- a/data/interfaces/default/config.html
+++ b/data/interfaces/default/config.html
@@ -560,6 +560,10 @@ m<%inherit file="base.html"/>
 							<label>Log Directory:</label>
 							<input type="text" name="log_dir" value="${config['log_dir']}" size="50">
 						</div>
+						<div class="row">
+							<label>Cache Directory:</label>
+							<input type="text" name="cache_dir" value="${config['cache_dir']}" size="50">
+						</div>
 					</fieldset>
 						            	
                                         

--- a/data/interfaces/remix/config.html
+++ b/data/interfaces/remix/config.html
@@ -342,6 +342,8 @@
 						</select>
 						<br><br>
                     	<h3>Log Directory:</h3><input type="text" name="log_dir" value="${config['log_dir']}" size="50">
+						<br><br>
+                    	<h3>Cache Directory:</h3><input type="text" name="cache_dir" value="${config['cache_dir']}" size="50">
                 </td>
             </tr>
             <tr>

--- a/headphones/__init__.py
+++ b/headphones/__init__.py
@@ -296,6 +296,7 @@ def initialize():
         API_KEY = check_setting_str(CFG, 'General', 'api_key', '')
         GIT_PATH = check_setting_str(CFG, 'General', 'git_path', '')
         LOG_DIR = check_setting_str(CFG, 'General', 'log_dir', '')
+        CACHE_DIR = check_setting_str(CFG, 'General', 'cache_dir', '')
         
         CHECK_GITHUB = bool(check_setting_int(CFG, 'General', 'check_github', 1))
         CHECK_GITHUB_ON_STARTUP = bool(check_setting_int(CFG, 'General', 'check_github_on_startup', 1))
@@ -469,8 +470,9 @@ def initialize():
         # Start the logger, silence console logging if we need to
         logger.headphones_log.initLogger(verbose=VERBOSE)
         
-        # Put the cache dir in the data dir for now
-        CACHE_DIR = os.path.join(DATA_DIR, 'cache')
+        if not CACHE_DIR:
+            # Put the cache dir in the data dir for now
+            CACHE_DIR = os.path.join(DATA_DIR, 'cache')
         if not os.path.exists(CACHE_DIR):
             try:
                 os.makedirs(CACHE_DIR)
@@ -576,6 +578,7 @@ def config_write():
     new_config['General']['api_enabled'] = int(API_ENABLED)
     new_config['General']['api_key'] = API_KEY
     new_config['General']['log_dir'] = LOG_DIR
+    new_config['General']['cache_dir'] = CACHE_DIR
     new_config['General']['git_path'] = GIT_PATH
     
     new_config['General']['check_github'] = int(CHECK_GITHUB)

--- a/headphones/webserve.py
+++ b/headphones/webserve.py
@@ -486,6 +486,7 @@ class WebInterface(object):
                     "autowant_upcoming" : checked(headphones.AUTOWANT_UPCOMING),
                     "autowant_all" : checked(headphones.AUTOWANT_ALL),
                     "log_dir" : headphones.LOG_DIR,
+                    "cache_dir" : headphones.CACHE_DIR,
                     "interface_list" : interface_list,
                     "music_encoder":        checked(headphones.MUSIC_ENCODER),
                     "encoder":      headphones.ENCODER,
@@ -548,7 +549,7 @@ class WebInterface(object):
         numberofseeders=10, use_isohunt=0, use_kat=0, use_mininova=0, waffles=0, waffles_uid=None, waffles_passkey=None, rename_files=0, correct_metadata=0, 
         cleanup_files=0, add_album_art=0, embed_album_art=0, embed_lyrics=0, destination_dir=None, lossless_destination_dir=None, folder_format=None, file_format=None, 
         include_extras=0, single=0, ep=0, compilation=0, soundtrack=0, live=0, remix=0, spokenword=0, audiobook=0, autowant_upcoming=False, autowant_all=False, 
-        interface=None, log_dir=None, music_encoder=0, encoder=None, bitrate=None, samplingfrequency=None, encoderfolder=None, advancedencoder=None, 
+        interface=None, log_dir=None, cache_dir=None,  music_encoder=0, encoder=None, bitrate=None, samplingfrequency=None, encoderfolder=None, advancedencoder=None, 
         encoderoutputformat=None, encodervbrcbr=None, encoderquality=None, encoderlossless=0, delete_lossless_files=0, prowl_enabled=0, prowl_onsnatch=0, 
         prowl_keys=None, prowl_priority=0, xbmc_enabled=0, xbmc_host=None, xbmc_username=None, xbmc_password=None, xbmc_update=0, xbmc_notify=0, nma_enabled=False, 
         nma_apikey=None, nma_priority=0, nma_onsnatch=0, synoindex_enabled=False, mirror=None, customhost=None, customport=None, customsleep=None, hpuser=None, hppass=None, 
@@ -616,6 +617,7 @@ class WebInterface(object):
         headphones.AUTOWANT_ALL = autowant_all
         headphones.INTERFACE = interface
         headphones.LOG_DIR = log_dir
+        headphones.CACHE_DIR = cache_dir
         headphones.MUSIC_ENCODER = music_encoder
         headphones.ENCODER = encoder
         headphones.BITRATE = int(bitrate)


### PR DESCRIPTION
This makes cache_dir editable via interfaces/config.  It's helpful for distros wanting to put the cache in /var/cache/headphones for example.

Thanks!
