### PR TITLE
Filter hidden Unix directories

### DIFF
--- a/headphones/librarysync.py
+++ b/headphones/librarysync.py
@@ -56,6 +56,11 @@ def libraryScan(dir=None, append=False, ArtistID=None, ArtistName=None):
     song_list = []
     
     for r,d,f in os.walk(dir):
+        #need to abuse slicing to get a copy of the list, doing it directly will skip the element after a deleted one
+        #using a list comprehension will not work correctly for nested subdirectories (os.walk keeps its original list)
+        for directory in d[:]:
+            if directory.startswith("."):
+                d.remove(directory)
         for files in f:
             # MEDIA_FORMATS = music file extensions, e.g. mp3, flac, etc
             if any(files.lower().endswith('.' + x.lower()) for x in headphones.MEDIA_FORMATS):


### PR DESCRIPTION
Fixes Issue #796.
As this will filter all directories starting with "." any band names/album names starting with a dot may be filtered too (depending on folder structure), the safer fix would likely be 81082be which filters only the directories known to cause issues
