### PR TITLE
absolute album artwork path breaks http_root setups

### DIFF
--- a/data/interfaces/default/album.html
+++ b/data/interfaces/default/album.html
@@ -51,7 +51,7 @@
 	<div class="table_wrapper">
 		<div id="albumheader" class="clearfix">	
 			<div id="albumImg">
-				<img height="200" alt="" class="albumArt" src="/artwork/album/${album['AlbumID']}">
+				<img height="200" alt="" class="albumArt" src="artwork/album/${album['AlbumID']}">
 			</div>
 			
 			<h1><a href="http://musicbrainz.org/release-group/${album['AlbumID']}">${album['AlbumTitle']}</a></h1>

--- a/data/interfaces/default/artist.html
+++ b/data/interfaces/default/artist.html
@@ -122,7 +122,7 @@
 			%>
 			<tr class="grade${grade}">
 				<td id="select"><input type="checkbox" name="${album['AlbumID']}" class="checkbox" /></td>
-				<td id="albumart"><img class="albumArt" id="${album['AlbumID']}" src="/artwork/thumbs/album/${album['AlbumID']}" height="64" width="64"></td>
+				<td id="albumart"><img class="albumArt" id="${album['AlbumID']}" src="artwork/thumbs/album/${album['AlbumID']}" height="64" width="64"></td>
 				<td id="albumname"><a href="albumPage?AlbumID=${album['AlbumID']}">${album['AlbumTitle']}</a></td>
 				<td id="reldate">${album['ReleaseDate']}</td>
 				<td id="type">${album['Type']}</td>

--- a/data/interfaces/default/index.html
+++ b/data/interfaces/default/index.html
@@ -35,7 +35,7 @@
                     "aTargets": [ 0 ],
                     "mData":"ArtistID",
                     "mRender": function ( data, type, full ) {
-                        return '<div id="artistImg"><img class="albumArt" alt="" id="'+ data + '" src="/artwork/thumbs/artist/' + data + '"/></div>';
+                        return '<div id="artistImg"><img class="albumArt" alt="" id="'+ data + '" src="artwork/thumbs/artist/' + data + '"/></div>';
                     }
                    },
                    {

--- a/data/interfaces/default/manageartists.html
+++ b/data/interfaces/default/manageartists.html
@@ -66,7 +66,7 @@
 			%>
 			<tr class="grade${grade}">
 				<td id="select"><input type="checkbox" name="${artist['ArtistID']}" class="checkbox" /></td>
-				<td id="albumart"><div id="artistImg"><img class="albumArt" id="${artist['ArtistID']}" src="/artwork/thumbs/artist/${artist['ArtistID']}" height="50" width="50"></div></td>
+				<td id="albumart"><div id="artistImg"><img class="albumArt" id="${artist['ArtistID']}" src="artwork/thumbs/artist/${artist['ArtistID']}" height="50" width="50"></div></td>
 				<td id="name"><span title="${artist['ArtistSortName']}"></span><a href="artistPage?ArtistID=${artist['ArtistID']}">${artist['ArtistName']}</a></td>
 				<td id="status">${artist['Status']}</td>	
 				<td id="album"><span title="${releasedate}"></span><a href="albumPage?AlbumID=${artist['AlbumID']}">${albumdisplay}</a></td>

--- a/data/interfaces/default/upcoming.html
+++ b/data/interfaces/default/upcoming.html
@@ -40,7 +40,7 @@
 		%for album in wanted:
 			<tr class="gradeZ">
 				<td id="select"><input type="checkbox" name="${album['AlbumID']}" class="checkbox" /></th>
-				<td id="albumart"><img title="${album['AlbumID']}" height="64" width="64" src="/artwork/thumbs/album/${album['AlbumID']}"></td>
+				<td id="albumart"><img title="${album['AlbumID']}" height="64" width="64" src="artwork/thumbs/album/${album['AlbumID']}"></td>
 				<td id="artistname"><a href="artistPage?ArtistID=${album['ArtistID']}">${album['ArtistName']}</a></td>
 				<td id="albumname"><a href="albumPage?AlbumID=${album['AlbumID']}">${album['AlbumTitle']}</a></td>
 				<td id="reldate">${album['ReleaseDate']}</td>
@@ -70,7 +70,7 @@
 		<tbody>
 		%for album in upcoming:
 			<tr class="gradeZ">
-				<td id="albumart"><img title="${album['AlbumID']}" height="64" width="64" src="/artwork/thumbs/album/${album['AlbumID']}"></td>
+				<td id="albumart"><img title="${album['AlbumID']}" height="64" width="64" src="artwork/thumbs/album/${album['AlbumID']}"></td>
 				<td id="artistname"><a href="artistPage?ArtistID=${album['ArtistID']}">${album['ArtistName']}</a></td>
 				<td id="albumname"><a href="albumPage?AlbumID=${album['AlbumID']}">${album['AlbumTitle']}</a></td>
 				<td id="reldate">${album['ReleaseDate']}</td>


### PR DESCRIPTION
I made the path for album artwork relative so the path wouldn't still go to root when http_root is set. 
