### PR TITLE
Fixes Issue #835 ,if the album name contains  < and > characters replace...

### DIFF
--- a/headphones/postprocessor.py
+++ b/headphones/postprocessor.py
@@ -376,7 +376,7 @@ def moveFiles(albumpath, release, tracks):
             
     
     folder = helpers.replace_all(headphones.FOLDER_FORMAT, values)
-    folder = folder.replace('./', '_/').replace(':','_').replace('?','_').replace('/.','/_')
+    folder = folder.replace('./', '_/').replace(':','_').replace('?','_').replace('/.','/_').replace('<','_').replace('>','_')
     
     if folder.endswith('.'):
         folder = folder.replace(folder[len(folder)-1], '_')


### PR DESCRIPTION
... them with _ before creating the folder (will fail on windows if we don't)
- / \ and | are also bad characters on windows and are not yet being handled
