### PR TITLE
Fix permissions on album art files

### DIFF
--- a/headphones/__init__.py
+++ b/headphones/__init__.py
@@ -221,6 +221,8 @@ HPPASS = None
 
 CACHE_SIZEMB = 32
 
+UMASK = None
+
 def CheckSection(sec):
     """ Check if INI section exists, if not create it """
     try:
@@ -286,7 +288,8 @@ def initialize():
                 PROWL_ENABLED, PROWL_PRIORITY, PROWL_KEYS, PROWL_ONSNATCH, PUSHOVER_ENABLED, PUSHOVER_PRIORITY, PUSHOVER_KEYS, PUSHOVER_ONSNATCH, MIRRORLIST, \
                 MIRROR, CUSTOMHOST, CUSTOMPORT, CUSTOMSLEEP, HPUSER, HPPASS, XBMC_ENABLED, XBMC_HOST, XBMC_USERNAME, XBMC_PASSWORD, XBMC_UPDATE, \
                 XBMC_NOTIFY, NMA_ENABLED, NMA_APIKEY, NMA_PRIORITY, NMA_ONSNATCH, SYNOINDEX_ENABLED, ALBUM_COMPLETION_PCT, PREFERRED_BITRATE_HIGH_BUFFER, \
-                PREFERRED_BITRATE_LOW_BUFFER, PREFERRED_BITRATE_ALLOW_LOSSLESS, CACHE_SIZEMB
+                PREFERRED_BITRATE_LOW_BUFFER, PREFERRED_BITRATE_ALLOW_LOSSLESS, CACHE_SIZEMB, \
+                UMASK
 
         if __INITIALIZED__:
             return False
@@ -574,6 +577,10 @@ def initialize():
                 LATEST_VERSION = CURRENT_VERSION
         else:
             LATEST_VERSION = CURRENT_VERSION
+
+        # Store the original umask
+        UMASK = os.umask(0)
+        os.umask(UMASK)
 
         __INITIALIZED__ = True
         return True

--- a/headphones/postprocessor.py
+++ b/headphones/postprocessor.py
@@ -448,7 +448,7 @@ def addAlbumArt(artwork, albumpath, release):
     if album_art_name.startswith('.'):
         album_art_name = album_art_name.replace(0, '_')
 
-    prev = os.umask(0002)
+    prev = os.umask(headphones.UMASK)
     file = open(os.path.join(albumpath, album_art_name), 'wb')
     file.write(artwork)
     file.close()

--- a/headphones/searcher.py
+++ b/headphones/searcher.py
@@ -672,9 +672,11 @@ def searchNZB(albumid=None, new=False, losslessOnly=False):
                     nzb_name = nzb_folder_name + '.nzb'
                     download_path = os.path.join(headphones.BLACKHOLE_DIR, nzb_name)
                     try:
+                        prev = os.umask(headphones.UMASK)
                         f = open(download_path, 'w')
                         f.write(data)
                         f.close()
+                        os.umask(prev)
                         logger.info('File saved to: %s' % nzb_name)
                     except Exception, e:
                         logger.error('Couldn\'t write NZB file: %s' % e)
@@ -1341,9 +1343,11 @@ def searchTorrent(albumid=None, new=False, losslessOnly=False):
 			                    break
                         else:  
 			                #Write the torrent file to a path derived from the TORRENTBLACKHOLE_DIR and file name.
+                            prev = os.umask(headphones.UMASK)
 			                torrent_file = open(download_path, 'wb')
 			                torrent_file.write(data)
 			                torrent_file.close()
+                            os.umask(prev)
 			                
 			            #Open the fresh torrent file again so we can extract the proper torrent name
 			            #Used later in post-processing.


### PR DESCRIPTION
Hi,
I noticed that album art files were written with incorrect (in my case) permissions. After some looking at the code, it seems that the daemonize-option sets umask to 0077, which is then used as well when writing album art and torrent files in the blackhole directory. This patch saves the original umask in a global configuration variable, which is then used when writing files which need to be world-readable, such as album art.

Regards,

Michel.
