### PR TITLE
Handle common newznab errors

### DIFF
--- a/headphones/searcher.py
+++ b/headphones/searcher.py
@@ -236,12 +236,15 @@ def searchNZB(albumid=None, new=False, losslessOnly=False):
                     data = False
                     
                 if data:
-                
                     d = feedparser.parse(data)
                     
                     if not len(d.entries):
-                        logger.info(u"No results found from %s for %s" % (newznab_host[0], term))
-                        pass
+                        if d.feed and d.feed.error:
+                            error = d.feed.error
+                            logger.error(u"Error from %s, %s: %s" % (newznab_host[0], error['code'], error['description']))
+                        else:
+                            logger.info(u"No results found from %s for %s" % (newznab_host[0], term))
+                            pass
                     
                     else:
                         for item in d.entries:


### PR DESCRIPTION
It seems common for newznab servers to return a 200 status with an error in the payload.

```
<error code="500" description="Request limit reached"/>
```

This changeset handles this case by logging the code and description as an error.

Tested the error paths on nzbndx.net and nzbs4u.com. I don't have a functioning newznab account to test the positive case at the moment.
