### PR TITLE
Handle FLAC albumart correctly.

### DIFF
--- a/lib/beets/mediafile.py
+++ b/lib/beets/mediafile.py
@@ -572,9 +572,23 @@ class ImageField(object):
 
             # No cover found.
             return None
+	elif obj.type == 'flac':
+            if 'metadata_block_picture' not in obj.mgfile:
+                return None
+
+            for data in obj.mgfile['metadata_block_picture']:
+                try:
+                    pic = lib.mutagen.flac.Picture(data)
+                    break
+                except TypeError:
+                    pass
+            else:
+                return None
+
+            return pic.data
 
         else:
-            # Here we're assuming everything but MP3 and MPEG-4 uses
+	    # Here we're assuming everything but MP3, FLAC and MPEG-4 use
             # the Xiph/Vorbis Comments standard. This may not be valid.
             # http://wiki.xiph.org/VorbisComment#Cover_art
 
@@ -623,6 +637,13 @@ class ImageField(object):
             else:
                 cover = lib.mutagen.mp4.MP4Cover(val, self._mp4kind(val))
                 obj.mgfile['covr'] = [cover]
+	
+        elif obj.type == 'flac':
+            if val is None:
+                pic = lib.mutagen.flac.Picture()
+                pic.data = val
+                pic.mime = self._mime(val)
+                obj.mgfile['metadata_block_picture'] = [pic.write()]
 
         else:
             # Again, assuming Vorbis Comments standard.


### PR DESCRIPTION
Fixing https://github.com/rembo10/headphones/issues/1284

I found out that headphones is corrupting FLAC files when it embeds artwork.

The biggest problem for me is that Subsonic won't play the corrupt files as discussed in this thread: http://forum.subsonic.org/forum/viewtopic.php?f=2&t=9434

The cause of the issue is not Headphones per se, rather a outdated beets library that embeds flac files the wrong way: sampsyo/beets@faa2139
