### PR TITLE
made postprocessing not pop up subprocess window

### DIFF
--- a/headphones/music_encoder.py
+++ b/headphones/music_encoder.py
@@ -244,7 +244,9 @@ def command(encoder,musicSource,musicDest,albumPath):
     logger.info('Encoding %s...' % (musicSource.decode(headphones.SYS_ENCODING, 'replace')))
     logger.debug(subprocess.list2cmdline(cmd))
 
-    p = subprocess.Popen(cmd, stdin=open(os.devnull, 'rb'), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    startupinfo = subprocess.STARTUPINFO()
+    startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+    p = subprocess.Popen(cmd, startupinfo=startupinfo, stdin=open(os.devnull, 'rb'), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
     stdout, stderr = p.communicate(headphones.ENCODER)
 


### PR DESCRIPTION
It can be annoying if you use the computer running headphones for other things like XBMC. This startupinfo hides the  console window from popping up without interrupting headphones parsing of any stdout, stderr, or stdin.
