### PR TITLE
Added ability to disable Download Scanner

### DIFF
--- a/headphones/__init__.py
+++ b/headphones/__init__.py
@@ -945,7 +945,8 @@ def start():
         if CHECK_GITHUB:
             SCHED.add_interval_job(versioncheck.checkGithub, minutes=CHECK_GITHUB_INTERVAL)
 
-        SCHED.add_interval_job(postprocessor.checkFolder, minutes=DOWNLOAD_SCAN_INTERVAL)
+	if DOWNLOAD_SCAN_INTERVAL > 0:
+            SCHED.add_interval_job(postprocessor.checkFolder, minutes=DOWNLOAD_SCAN_INTERVAL)
 
         SCHED.start()
 


### PR DESCRIPTION
Setting download scan interval to 0 now will disable the download scanner from checking for music to be processed. 

This also helps resolve any issues that the download scanner was causing with nzbToMedia when it was trying to do its processing at the same time.
