### PR TITLE
Added ability to set a seperate post-processing folder

### DIFF
--- a/data/interfaces/default/config.html
+++ b/data/interfaces/default/config.html
@@ -508,6 +508,11 @@
                                     <input type="checkbox" name="embed_lyrics" value="1" ${config['embed_lyrics']}><label>Embed lyrics</label>
                                 </div>
                                 <div class="row">
+                                    <label>Path to Post-Processing Folder</label>
+                                    <input type="text" name="post_processing_dir" value="${config['post_processing_dir']}" size="50">
+                                    <small>Set this to where your download client puts its completed downloads in</small>
+                                </div>
+                                <div class="row">
                                     <label>Path to Destination Folder</label>
                                     <input type="text" name="destination_dir" value="${config['dest_dir']}" size="50">
                                     <small>e.g. /Users/name/Music/iTunes or /Volumes/share/music</small>

--- a/headphones/__init__.py
+++ b/headphones/__init__.py
@@ -92,6 +92,7 @@ CHECK_GITHUB = False
 CHECK_GITHUB_ON_STARTUP = False
 CHECK_GITHUB_INTERVAL = None
 
+POST_PROCESSING_DIR = None
 MUSIC_DIR = None
 DESTINATION_DIR = None
 LOSSLESS_DESTINATION_DIR = None
@@ -318,7 +319,7 @@ def initialize():
                 PROWL_ENABLED, PROWL_PRIORITY, PROWL_KEYS, PROWL_ONSNATCH, PUSHOVER_ENABLED, PUSHOVER_PRIORITY, PUSHOVER_KEYS, PUSHOVER_ONSNATCH, MIRRORLIST, \
                 MIRROR, CUSTOMHOST, CUSTOMPORT, CUSTOMSLEEP, HPUSER, HPPASS, XBMC_ENABLED, XBMC_HOST, XBMC_USERNAME, XBMC_PASSWORD, XBMC_UPDATE, \
                 XBMC_NOTIFY, NMA_ENABLED, NMA_APIKEY, NMA_PRIORITY, NMA_ONSNATCH, SYNOINDEX_ENABLED, ALBUM_COMPLETION_PCT, PREFERRED_BITRATE_HIGH_BUFFER, \
-                PREFERRED_BITRATE_LOW_BUFFER, PREFERRED_BITRATE_ALLOW_LOSSLESS, CACHE_SIZEMB, JOURNAL_MODE, UMASK, ENABLE_HTTPS, HTTPS_CERT, HTTPS_KEY
+                PREFERRED_BITRATE_LOW_BUFFER, PREFERRED_BITRATE_ALLOW_LOSSLESS, CACHE_SIZEMB, JOURNAL_MODE, UMASK, ENABLE_HTTPS, HTTPS_CERT, HTTPS_KEY, POST_PROCESSING_DIR
 
         if __INITIALIZED__:
             return False
@@ -376,6 +377,7 @@ def initialize():
         CHECK_GITHUB_ON_STARTUP = bool(check_setting_int(CFG, 'General', 'check_github_on_startup', 1))
         CHECK_GITHUB_INTERVAL = check_setting_int(CFG, 'General', 'check_github_interval', 360)
 
+        POST_PROCESSING_DIR = check_setting_str(CFG, 'General', 'post_processing_dir', '')
         MUSIC_DIR = check_setting_str(CFG, 'General', 'music_dir', '')
         DESTINATION_DIR = check_setting_str(CFG, 'General', 'destination_dir', '')
         LOSSLESS_DESTINATION_DIR = check_setting_str(CFG, 'General', 'lossless_destination_dir', '')
@@ -746,6 +748,7 @@ def config_write():
     new_config['General']['check_github_on_startup'] = int(CHECK_GITHUB_ON_STARTUP)
     new_config['General']['check_github_interval'] = CHECK_GITHUB_INTERVAL
 
+    new_config['General']['post_processing_dir'] = POST_PROCESSING_DIR
     new_config['General']['music_dir'] = MUSIC_DIR
     new_config['General']['destination_dir'] = DESTINATION_DIR
     new_config['General']['lossless_destination_dir'] = LOSSLESS_DESTINATION_DIR

--- a/headphones/postprocessor.py
+++ b/headphones/postprocessor.py
@@ -55,7 +55,7 @@ def checkFolder():
                     
                     for nzb_folder_name in nzb_album_possibilities:
                         
-                        nzb_album_path = os.path.join(headphones.DOWNLOAD_DIR, nzb_folder_name).encode(headphones.SYS_ENCODING, 'replace')
+                        nzb_album_path = os.path.join(headphones.POST_PROCESSING_DIR, nzb_folder_name).encode(headphones.SYS_ENCODING, 'replace')
     
                         if os.path.exists(nzb_album_path):
                             logger.debug('Found %s in NZB download folder. Verifying....' % album['FolderName'])
@@ -63,7 +63,7 @@ def checkFolder():
                             
                 if album['Kind'] == 'torrent':
 
-                    torrent_album_path = os.path.join(headphones.DOWNLOAD_TORRENT_DIR, album['FolderName']).encode(headphones.SYS_ENCODING,'replace')
+                    torrent_album_path = os.path.join(headphones.POST_PROCESSING_DIR, album['FolderName']).encode(headphones.SYS_ENCODING,'replace')
     
                     if os.path.exists(torrent_album_path):
                         logger.debug('Found %s in torrent download folder. Verifying....' % album['FolderName'])
@@ -896,15 +896,10 @@ def renameUnprocessedFolder(albumpath):
 def forcePostProcess():
 
     download_dirs = []
-    if headphones.DOWNLOAD_DIR:
-        download_dirs.append(headphones.DOWNLOAD_DIR.encode(headphones.SYS_ENCODING, 'replace'))
-    if headphones.DOWNLOAD_TORRENT_DIR:
-        download_dirs.append(headphones.DOWNLOAD_TORRENT_DIR.encode(headphones.SYS_ENCODING, 'replace'))
+    if headphones.POST_PROCESSING_DIR:
+        download_dirs.append(headphones.POST_PROCESSING_DIR.encode(headphones.SYS_ENCODING, 'replace'))
         
-    # If DOWNLOAD_DIR and DOWNLOAD_TORRENT_DIR are the same, remove the duplicate to prevent us from trying to process the same folder twice.
-    download_dirs = list(set(download_dirs))
-    
-    logger.info('Checking to see if there are any folders to process in download_dir(s): %s' % str(download_dirs).decode(headphones.SYS_ENCODING, 'replace'))
+    logger.info('Checking to see if there are any folders to process in: %s' % str(download_dirs).decode(headphones.SYS_ENCODING, 'replace'))
     # Get a list of folders in the download_dir
     folders = []
     for download_dir in download_dirs:

--- a/headphones/webserve.py
+++ b/headphones/webserve.py
@@ -951,7 +951,8 @@ class WebInterface(object):
                     "hppass": headphones.HPPASS,
                     "cache_sizemb": headphones.CACHE_SIZEMB,
                     "file_permissions": headphones.FILE_PERMISSIONS,
-                    "folder_permissions": headphones.FOLDER_PERMISSIONS
+                    "folder_permissions": headphones.FOLDER_PERMISSIONS,
+                    "post_processing_dir" : headphones.POST_PROCESSING_DIR
                 }
 
         # Need to convert EXTRAS to a dictionary we can pass to the config: it'll come in as a string like 2,5,6,8
@@ -986,7 +987,7 @@ class WebInterface(object):
         xbmc_update=0, xbmc_notify=0, nma_enabled=False, nma_apikey=None, nma_priority=0, nma_onsnatch=0, synoindex_enabled=False,
         pushover_enabled=0, pushover_onsnatch=0, pushover_keys=None, pushover_priority=0, mirror=None, customhost=None, customport=None,
         customsleep=None, hpuser=None, hppass=None, preferred_bitrate_high_buffer=None, preferred_bitrate_low_buffer=None, preferred_bitrate_allow_lossless=0, cache_sizemb=None, 
-        enable_https=0, https_cert=None, https_key=None, file_permissions=None, folder_permissions=None, **kwargs):
+        enable_https=0, https_cert=None, https_key=None, file_permissions=None, folder_permissions=None, post_processing_dir=None, **kwargs):
 
         headphones.HTTP_HOST = http_host
         headphones.HTTP_PORT = http_port
@@ -1123,6 +1124,7 @@ class WebInterface(object):
         headphones.CACHE_SIZEMB = int(cache_sizemb)
         headphones.FILE_PERMISSIONS = file_permissions
         headphones.FOLDER_PERMISSIONS = folder_permissions
+	headphones.POST_PROCESSING_DIR = post_processing_dir
 
         # Handle the variable config options. Note - keys with False values aren't getting passed
 


### PR DESCRIPTION
You now can set a separate post-processing directory allowing you to download to a separate directory as well.
This should resolve any issues with nzbToMedia and Headphones when trying to post-process downloaded files.
