### PR TITLE
Filter Songkick results based on location

### DIFF
--- a/data/interfaces/default/artist.html
+++ b/data/interfaces/default/artist.html
@@ -269,7 +269,9 @@
 		initActions();
 		initThisPage();
 		getArtistBio();
-		getArtistsCalendar();
+		if( ${headphones.SONGKICK_ENABLED} ){
+      getArtistsCalendar();
+    }
 	});
 
 	</script>

--- a/data/interfaces/default/config.html
+++ b/data/interfaces/default/config.html
@@ -970,17 +970,22 @@
 
                             <fieldset>
                                 <legend>Songkick</legend>
-                                <div class="row">
-                                    <label>API Key:</label>
-                                    <input type="text" name="songkick_apikey" value="${config['songkick_apikey']}" size="50">
-                                </div>
                                 <div class="row checkbox">
-                                    <input type="checkbox" name="songkick_filter_enabled" id="songkick_filter" value="1" ${config['songkick_filter_enabled']} /><label>Enable Songkick filter per area</label>
+                                    <input type="checkbox" name="songkick_enabled" id="songkick" value="1" ${config['songkick_enabled']} /><label>Display concerts by Songkick</label>
                                 </div>
-                                <div id="songkick_filteroptions">
+                                <div id="songkickoptions">
                                   <div class="row">
-                                    <label>Location:</label>
-                                    <input type="text" name="songkick_location" value="${config['songkick_location']}" size="50">
+                                      <label>API Key:</label>
+                                      <input type="text" name="songkick_apikey" value="${config['songkick_apikey']}" size="50">
+                                  </div>
+                                  <div class="row checkbox">
+                                      <input type="checkbox" name="songkick_filter_enabled" id="songkick_filter" value="1" ${config['songkick_filter_enabled']} /><label>Enable Songkick filter per area</label>
+                                  </div>
+                                  <div id="songkick_filteroptions">
+                                    <div class="row">
+                                      <label>Location:</label>
+                                      <input type="text" name="songkick_location" value="${config['songkick_location']}" size="50">
+                                    </div>
                                   </div>
                                 </div>
                             </fieldset>
@@ -1334,6 +1339,26 @@
                         else
                         {
                                 $("#twitteroptions").slideUp();
+                        }
+                });
+                
+                 if ($("#songkick").is(":checked"))
+                        {
+                                $("#songkickoptions").show();
+                        }
+                else
+                        {
+                                $("#songkickoptions").hide();
+                        }
+
+                $("#songkick").click(function(){
+                        if ($("#songkick").is(":checked"))
+                        {
+                                $("#songkickoptions").slideDown();
+                        }
+                        else
+                        {
+                                $("#songkickoptions").slideUp();
                         }
                 });
                 

--- a/headphones/__init__.py
+++ b/headphones/__init__.py
@@ -265,6 +265,7 @@ CUSTOMPORT = None
 CUSTOMSLEEP = None
 HPUSER = None
 HPPASS = None
+SONGKICK_ENABLED = False
 SONGKICK_APIKEY = None
 SONGKICK_LOCATION = None
 SONGKICK_FILTER_ENABLED = False
@@ -344,7 +345,7 @@ def initialize():
                 MIRROR, CUSTOMHOST, CUSTOMPORT, CUSTOMSLEEP, HPUSER, HPPASS, XBMC_ENABLED, XBMC_HOST, XBMC_USERNAME, XBMC_PASSWORD, XBMC_UPDATE, \
                 XBMC_NOTIFY, NMA_ENABLED, NMA_APIKEY, NMA_PRIORITY, NMA_ONSNATCH, SYNOINDEX_ENABLED, ALBUM_COMPLETION_PCT, PREFERRED_BITRATE_HIGH_BUFFER, \
                 PREFERRED_BITRATE_LOW_BUFFER, PREFERRED_BITRATE_ALLOW_LOSSLESS, CACHE_SIZEMB, JOURNAL_MODE, UMASK, ENABLE_HTTPS, HTTPS_CERT, HTTPS_KEY, \
-                PLEX_ENABLED, PLEX_SERVER_HOST, PLEX_CLIENT_HOST, PLEX_USERNAME, PLEX_PASSWORD, PLEX_UPDATE, PLEX_NOTIFY, PUSHALOT_ENABLED, PUSHALOT_APIKEY, PUSHALOT_ONSNATCH, SONGKICK_APIKEY, SONGKICK_LOCATION, SONGKICK_FILTER_ENABLED, \
+                PLEX_ENABLED, PLEX_SERVER_HOST, PLEX_CLIENT_HOST, PLEX_USERNAME, PLEX_PASSWORD, PLEX_UPDATE, PLEX_NOTIFY, PUSHALOT_ENABLED, PUSHALOT_APIKEY, PUSHALOT_ONSNATCH, SONGKICK_ENABLED, SONGKICK_APIKEY, SONGKICK_LOCATION, SONGKICK_FILTER_ENABLED, \
                 POST_PROCESSING_DIR
 
 
@@ -583,6 +584,7 @@ def initialize():
         TWITTER_PASSWORD = check_setting_str(CFG, 'Twitter', 'twitter_password', '')
         TWITTER_PREFIX = check_setting_str(CFG, 'Twitter', 'twitter_prefix', 'Headphones')
         
+        SONGKICK_ENABLED = bool(check_setting_str(CFG, 'Songkick', 'songkick_enabled', 0))
         SONGKICK_APIKEY = check_setting_str(CFG, 'Songkick', 'songkick_apikey', '')
         SONGKICK_LOCATION = check_setting_str(CFG, 'Songkick', 'songkick_location', '')
         SONGKICK_FILTER_ENABLED = bool(check_setting_str(CFG, 'Songkick', 'songkick_filter_enabled', 0))
@@ -982,6 +984,7 @@ def config_write():
     new_config['Twitter']['twitter_prefix'] = TWITTER_PREFIX
 
     new_config['Songkick'] = {}
+    new_config['Songkick']['songkick_enabled'] = SONGKICK_ENABLED
     new_config['Songkick']['songkick_apikey'] = SONGKICK_APIKEY
     new_config['Songkick']['songkick_location'] = SONGKICK_LOCATION
     new_config['Songkick']['songkick_filter_enabled'] = SONGKICK_FILTER_ENABLED

--- a/headphones/webserve.py
+++ b/headphones/webserve.py
@@ -973,6 +973,7 @@ class WebInterface(object):
                     "customsleep": headphones.CUSTOMSLEEP,
                     "hpuser": headphones.HPUSER,
                     "hppass": headphones.HPPASS,
+                    "songkick_enabled": checked(headphones.SONGKICK_ENABLED),
                     "songkick_apikey": headphones.SONGKICK_APIKEY,
                     "songkick_location": headphones.SONGKICK_LOCATION,
                     "songkick_filter_enabled": checked(headphones.SONGKICK_FILTER_ENABLED),
@@ -1015,7 +1016,7 @@ class WebInterface(object):
         pushover_enabled=0, pushover_onsnatch=0, pushover_keys=None, pushover_priority=0, pushbullet_enabled=0, pushbullet_onsnatch=0, pushbullet_apikey=None, pushbullet_deviceid=None, twitter_enabled=0, twitter_onsnatch=0, mirror=None, customhost=None, customport=None,
         customsleep=None, hpuser=None, hppass=None, preferred_bitrate_high_buffer=None, preferred_bitrate_low_buffer=None, preferred_bitrate_allow_lossless=0, cache_sizemb=None, 
         enable_https=0, https_cert=None, https_key=None, file_permissions=None, folder_permissions=None, plex_enabled=0, plex_server_host=None, plex_client_host=None, plex_username=None, 
-        plex_password=None, plex_update=0, plex_notify=0, post_processing_dir=None, songkick_apikey=None, songkick_location=None, songkick_filter_enabled=0, **kwargs):
+        plex_password=None, plex_update=0, plex_notify=0, post_processing_dir=None, songkick_enabled=0, songkick_apikey=None, songkick_location=None, songkick_filter_enabled=0, **kwargs):
 
         headphones.HTTP_HOST = http_host
         headphones.HTTP_PORT = http_port
@@ -1157,6 +1158,7 @@ class WebInterface(object):
         headphones.PUSHBULLET_ONSNATCH = pushbullet_onsnatch
         headphones.PUSHBULLET_APIKEY = pushbullet_apikey
         headphones.PUSHBULLET_DEVICEID = pushbullet_deviceid
+        headphones.SONGKICK_ENABLED = songkick_enabled
         headphones.SONGKICK_APIKEY = songkick_apikey
         headphones.SONGKICK_LOCATION = songkick_location
         headphones.SONGKICK_FILTER_ENABLED = songkick_filter_enabled


### PR DESCRIPTION
The Songkick API key was not stored in config.ini, and the default value was stored in **init**.py
I removed it from there and it's now saving properly in config.ini

I added an optional configuration to filter per location.
So far it's only working with a numerical metro-area id.

TODO:
- I would like to change the Songkick configuration section to make it completely optional.
- I need to dig a bit on the API key topic for songkick, not sure it should have a default one (same as all the notification services) like what @maiis did in his pull request.
- I would need to add some kind of search button to find a location using actual words
