### PR TITLE
Change pushover notification title

### DIFF
--- a/headphones/postprocessor.py
+++ b/headphones/postprocessor.py
@@ -446,7 +446,7 @@ def doPostProcessing(albumid, albumpath, release, tracks, downloaded_track_list,
         pushmessage = release['ArtistName'] + ' - ' + release['AlbumTitle']
         logger.info(u"Pushover request")
         pushover = notifiers.PUSHOVER()
-        pushover.notify(pushmessage,"Download and Postprocessing completed")
+        pushover.notify(pushmessage,"Headphones")
 
     if headphones.PUSHBULLET_ENABLED:
         pushmessage = release['ArtistName'] + ' - ' + release['AlbumTitle']


### PR DESCRIPTION
Makes more sense to set pushover notification titles as "Headphones" rather than "Download and Postprocessing completed" - which may be too long (gets word-wrapped on android app depending on screen resolution) and not descriptive when you have lots of other notifications coming in. If that verbiage is desired, it would be better in the "pushmessage" body. 

This may apply to the other notification types as well, but not sure as I don't use them.
