### PR TITLE
Fixed: Tracklisting on the index screwed up

### DIFF
--- a/headphones/webserve.py
+++ b/headphones/webserve.py
@@ -273,7 +273,7 @@ class WebInterface(object):
                 ArtistIDT = ArtistID
             else:
                 ArtistIDT = myDB.action('SELECT ArtistID FROM albums WHERE AlbumID=?', [mbid]).fetchone()[0]
-            myDB.action('UPDATE artists SET TotalTracks=(SELECT COUNT(*) FROM tracks WHERE ArtistID = ? AND AlbumTitle IN (SELECT AlbumTitle FROM albums WHERE Status != "Ignored")) WHERE ArtistID=(SELECT ArtistID FROM albums WHERE AlbumID=?)', [ArtistIDT, mbid])
+            myDB.action('UPDATE artists SET TotalTracks=(SELECT COUNT(*) FROM tracks WHERE ArtistID = ? AND AlbumTitle IN (SELECT AlbumTitle FROM albums WHERE Status != "Ignored")) WHERE ArtistID = ?', [ArtistIDT, ArtistIDT])
         if ArtistID:
             raise cherrypy.HTTPRedirect("artistPage?ArtistID=%s" % ArtistID)
         else:


### PR DESCRIPTION
Seems my query didn't really make sense. Everytime you'd change the status of an album, it would count ALL the tracks in the database as a TotalTracks for that one artist the album belongs to.
This has been fixed and tested a bit more thoroughly (e.g. with 2 artists with the same name).
