### PR TITLE
A few database fixes

### DIFF
--- a/headphones/db.py
+++ b/headphones/db.py
@@ -61,11 +61,12 @@ class DBConnection:
         sqlResult = None
         
         try:
-            if args == None:
-                sqlResult = self.connection.execute(query)
-            else:
-                sqlResult = self.connection.execute(query, args)
-            self.connection.commit()
+            with self.connection as c:
+                if args == None:
+                    sqlResult = c.execute(query)
+                else:
+                    sqlResult = c.execute(query, args)
+                    
         except sqlite3.OperationalError, e:
             if "unable to open database file" in e.message or "database is locked" in e.message:
                 logger.warn('Database Error: %s', e)


### PR DESCRIPTION
- First commit prevents a 'valid' record from being returned when the result from a Select is [None]. This could be seen to be happening in #1691 with the rg_exists check in importer.py
- Second commit takes away a rather pointless attempt to query the database over and over once a lock is reported - I've read the documentation and that lock will only be reported as an exception after the specified time out has passed (20 seconds). If a simple insert/select is not returning inside 20 seconds, the database is not going to get unlocked by trying for another 84 seconds. 
- Last commit uses the Python 'with' statement to make the commit() to the database more reliable - reading the documentation this ensures that _no matter what_ the transaction will either be commited or rolled back depending on whether there are any problems. In #1438 I believe we are seeing an issue where the code fails before reaching the commit() line on an insert - this leaves the database in a permanently locked state. There may well be other issues open with the same problem, I've not checked. 
