### PR TITLE
Fix incorrect logging

### DIFF
--- a/headphones/searcher.py
+++ b/headphones/searcher.py
@@ -1014,7 +1014,7 @@ def searchTorrent(album, new=False, losslessOnly=False):
         # Process feed
         if data:
             if not len(data.entries):
-                logger.info(u"No results found from %s for %s" % provider, term)
+                logger.info(u"No results found from %s for %s" % (provider, term) )
             else:
                 for item in data.entries:
                     try:


### PR DESCRIPTION
This line causes an exception that means search fails.
I've wrapped it into a tuple, but I don't know if I can just pass the string formatting off to the logger.
