### PR TITLE
fix 1840, calling unexpected argument

### DIFF
--- a/headphones/postprocessor.py
+++ b/headphones/postprocessor.py
@@ -609,9 +609,9 @@ def addAlbumArt(artwork, albumpath, release):
 def cleanupFiles(albumpath):
     logger.info('Cleaning up files')
     if headphones.KEEP_NFO:
-        files = find_in_path(albumpath, extra_formats="nfo", inverted=True)
+        files = find_in_path(albumpath, extra_formats="nfo")
     else:
-        files = find_in_path(albumpath, inverted=True)
+        files = find_in_path(albumpath)
     for _f in files:
         logger.debug('Removing: %s' % _f)
         try:


### PR DESCRIPTION
Addresses the bug reported in #1840 and introduced in #1823 
