### PR TITLE
Fixes for TPB and KAT search engine

### DIFF
--- a/headphones/request.py
+++ b/headphones/request.py
@@ -170,13 +170,22 @@ def server_message(response):
     message = None
 
     # First attempt is to 'read' the response as HTML
-    if response.headers.get("content-type") == "text/html":
+    if "text/html" in response.headers.get("content-type"):
         try:
             soup = BeautifulSoup(response.content, "html5lib")
         except Exception:
             pass
 
+        # Find body and cleanup common tags to grab content, which probably
+        # contains the message.
         message = soup.find("body")
+
+        for element in ["header", "script", "footer", "nav", "input",
+            "textarea"]:
+
+            for tag in soup.find_all(element):
+                tag.replaceWith("")
+
         message = message.text if message else soup.text
         message = message.strip()
 


### PR DESCRIPTION
Both engines don't like the use of characters like `!`, so I filter them out before searching. Also, TPB changed URL parameters for sorting by seeds.

In addition, I fixed the scraping of messages in the responses, when verbose is toggled.

This fixes issue #1886, and improves for #1859.
