### PR TITLE
Increase Last.FM rate limit to 5 req/sec. Improved rate limiting

### DIFF
--- a/headphones/lastfm.py
+++ b/headphones/lastfm.py
@@ -23,7 +23,7 @@ from headphones import db, logger, request
 from collections import defaultdict
 
 TIMEOUT = 60.0 # seconds
-REQUEST_LIMIT = 1.0 # seconds
+REQUEST_LIMIT = 1.0 / 5 # seconds
 ENTRY_POINT = "http://ws.audioscrobbler.com/2.0/"
 API_KEY = "395e6ec6bb557382fc41fde867bce66f"
 


### PR DESCRIPTION
I introduced a problem with my last commit by moving the request method inside the lock: it did not parallelize the requests, with the consequence that a long request would block all threads due to the lock. The comment block will explain how it works now.

Furthermore, the Last.FM rate is increased.
