### PR TITLE
Possible fix for renaming files "TypeError: must be unicode, not str"

### DIFF
--- a/headphones/helpers.py
+++ b/headphones/helpers.py
@@ -178,9 +178,9 @@ def replace_all(text, dic, normalize=False):
     for i, j in dic.iteritems():
         if normalize:
             if sys.platform == 'darwin':
-                j = unicodedata.normalize('NFD', j)
+                j = unicodedata.normalize('NFD', unicode(j))
             else:
-                j = unicodedata.normalize('NFC', j)
+                j = unicodedata.normalize('NFC', unicode(j))
         text = text.replace(i, j)
     return text
 


### PR DESCRIPTION
ERROR   :: Thread-17 : Uncaught exception: Traceback (most recent call last):
  File "/data/headphones/headphones/logger.py", line 204, in new_run
    old_run(_args, *_kwargs)
  File "/usr/lib/python2.7/threading.py", line 763, in run
    self.__target(_self.__args, *_self.__kwargs)
  File "/data/headphones/headphones/postprocessor.py", line 1129, in forcePostProcess
    verify(release['AlbumID'], folder)
  File "/data/headphones/headphones/postprocessor.py", line 264, in verify
    doPostProcessing(albumid, albumpath, release, tracks, downloaded_track_list, Kind)
  File "/data/headphones/headphones/postprocessor.py", line 421, in doPostProcessing
    albumpaths = moveFiles(albumpath, release, tracks)
  File "/data/headphones/headphones/postprocessor.py", line 664, in moveFiles
    folder = helpers.replace_all(headphones.FOLDER_FORMAT.strip(), values, normalize=True)
  File "/data/headphones/headphones/helpers.py", line 183, in replace_all
    j = unicodedata.normalize('NFC', j)
TypeError: must be unicode, not str
