### PR TITLE
Fix argument to turn SSL cert checking on and off

### DIFF
--- a/headphones/request.py
+++ b/headphones/request.py
@@ -47,7 +47,7 @@ def request_response(url, method="get", auto_raise=True,
 
     # Disable verification of SSL certificates if requested. Note: this could
     # pose a security issue!
-    kwargs["verify"] = headphones.CONFIG.VERIFY_SSL_CERT
+    kwargs["verify"] = bool(headphones.CONFIG.VERIFY_SSL_CERT)
 
     # Map method to the request.XXX method. This is a simple hack, but it allows
     # requests to apply more magic per method. See lib/requests/api.py.


### PR DESCRIPTION
There might need to be another adjustment for how variables are cast as they go into and come out of the config, but casting the setting as it is used should future-proof that at least a little.
