### PR TITLE
Fix various config keys and template config keys

### DIFF
--- a/data/interfaces/default/config.html
+++ b/data/interfaces/default/config.html
@@ -50,13 +50,13 @@
                                     <label title="Username for web server authentication. Leave empty to disable.">
                                         HTTP Username
                                     </label>
-                                    <input type="text" name="http_username" value="${config['http_user']}" size="30">
+                                    <input type="text" name="http_username" value="${config['http_username']}" size="30">
                                 </div>
                                 <div class="row">
                                     <label title="Password for web server authentication. Leave empty to disable.">
                                         HTTP Password
                                     </label>
-                                    <input type="password" name="http_password" value="${config['http_pass']}" size="30">
+                                    <input type="password" name="http_password" value="${config['http_password']}" size="30">
                                 </div>
                                 <div class="row checkbox">
                                     <input type="checkbox" name="launch_browser" value="1" ${config['launch_browser']} />
@@ -166,25 +166,25 @@
                                     <label title="SABnzbd username. Leave empty if not applicable.">
                                         SABnzbd Username
                                     </label>
-                                    <input type="text" name="sab_username" value="${config['sab_user']}" size="20">
+                                    <input type="text" name="sab_username" value="${config['sab_username']}" size="20">
                                 </div>
                                 <div class="row">
                                     <label title="SABnzbd password. Leave empty if not applicable.">
                                         SABnzbd Password
                                     </label>
-                                    <input type="password" name="sab_password" value="${config['sab_pass']}" size="20">
+                                    <input type="password" name="sab_password" value="${config['sab_password']}" size="20">
                                 </div>
                                 <div class="row">
                                     <label title="SABnzbd API key. Can be found in SABnzbd settings.">
                                         SABnzbd API key
                                     </label>
-                                    <input type="text" name="sab_apikey" value="${config['sab_api']}" size="36">
+                                    <input type="text" name="sab_apikey" value="${config['sab_apikey']}" size="36">
                                 </div>
                                 <div class="row">
                                     <label title="Name of SABnzbd category to add downloads to.">
                                         SABnzbd Category
                                     </label>
-                                    <input type="text" name="sab_category" value="${config['sab_cat']}" size="20">
+                                    <input type="text" name="sab_category" value="${config['sab_category']}" size="20">
                                 </div>
                             </fieldset>
 
@@ -200,19 +200,19 @@
                                     <label title="NZBGet username. Leave empty if not applicable">
                                         NZBget Username
                                     </label>
-                                    <input type="text" name="nzbget_username" value="${config['nzbget_user']}" size="20">
+                                    <input type="text" name="nzbget_username" value="${config['nzbget_username']}" size="20">
                                 </div>
                                 <div class="row">
                                     <label title="NZBGet password. Leave empty if not applicable">
                                         NZBget Password
                                     </label>
-                                    <input type="password" name="nzbget_password" value="${config['nzbget_pass']}" size="20">
+                                    <input type="password" name="nzbget_password" value="${config['nzbget_password']}" size="20">
                                 </div>
                                 <div class="row">
                                     <label title="Name of NZBget category to add downloads to.">
                                         NZBget Category
                                     </label>
-                                    <input type="text" name="nzbget_category" value="${config['nzbget_cat']}" size="20">
+                                    <input type="text" name="nzbget_category" value="${config['nzbget_category']}" size="20">
                                 </div>
                                 <%
                                     if config['nzbget_priority'] == -100:
@@ -348,11 +348,11 @@
                                 </div>
                                 <div class="row">
                                     <label>Transmission Username</label>
-                                    <input type="text" name="transmission_username" value="${config['transmission_user']}" size="30">
+                                    <input type="text" name="transmission_username" value="${config['transmission_username']}" size="30">
                                 </div>
                                 <div class="row">
                                     <label>Transmission Password</label>
-                                    <input type="password" name="transmission_password" value="${config['transmission_pass']}" size="30">
+                                    <input type="password" name="transmission_password" value="${config['transmission_password']}" size="30">
                                 </div>
                                 <div class="row">
                                     <small>Note: With Transmission, you can specify a different download directory for downloads sent from Headphones.
@@ -368,11 +368,11 @@
                                 </div>
                                 <div class="row">
                                     <label>uTorrent Username</label>
-                                    <input type="text" name="utorrent_username" value="${config['utorrent_user']}" size="30">
+                                    <input type="text" name="utorrent_username" value="${config['utorrent_username']}" size="30">
                                 </div>
                                 <div class="row">
                                     <label>uTorrent Password</label>
-                                    <input type="password" name="utorrent_password" value="${config['utorrent_pass']}" size="30">
+                                    <input type="password" name="utorrent_password" value="${config['utorrent_password']}" size="30">
                                 </div>
                                 <div class="row">
                                     <label>uTorrent Label</label>
@@ -445,7 +445,7 @@
                                         </div>
                                         <div class="row">
                                             <label>Newznab API</label>
-                                            <input type="text" name="newznab_apikey" value="${config['newznab_api']}" size="36">
+                                            <input type="text" name="newznab_apikey" value="${config['newznab_apikey']}" size="36">
                                         </div>
                                         <div class="row checkbox">
                                             <input id="newznab_enabled" type="checkbox" name="newznab_enabled" onclick="initConfigCheckbox($(this));" value="1" ${config['newznab_enabled']} /><label>Enabled</label>
@@ -667,15 +667,15 @@
                                     <div id="preferred_bitrate_options">
                                         <div class="row">
                                             Target bitrate
-                                            <input type="text" class="override-float" name="preferred_bitrate" value="${config['pref_bitrate']}" size="3">kbps<br>
+                                            <input type="text" class="override-float" name="preferred_bitrate" value="${config['preferred_bitrate']}" size="3">kbps<br>
                                         </div>
                                         <div class="row">
                                             <span style="padding-left: 20px">
-                                                Reject if <strong>less than</strong> <input type="text" class="override-float" name="preferred_bitrate_low_buffer" value="${config['pref_bitrate_low']}" size="3">% or <strong>more than</strong> <input type="text" class="override-float" name="preferred_bitrate_high_buffer" value="${config['pref_bitrate_high']}" size="3">% of the target size (leave blank for no limit)<br>
+                                                Reject if <strong>less than</strong> <input type="text" class="override-float" name="preferred_bitrate_low_buffer" value="${config['preferred_bitrate_low']}" size="3">% or <strong>more than</strong> <input type="text" class="override-float" name="preferred_bitrate_high_buffer" value="${config['preferred_bitrate_high']}" size="3">% of the target size (leave blank for no limit)<br>
                                             </span>
                                         </div>
                                         <div class="row checkbox left" style="padding-left: 20px">
-                                            <input type="checkbox" name="preferred_bitrate_allow_lossless" value="1" ${config['pref_bitrate_allow_lossless']}>
+                                            <input type="checkbox" name="preferred_bitrate_allow_lossless" value="1" ${config['preferred_bitrate_allow_lossless']}>
                                             <label>Allow lossless if no good lossy match found</label>
                                         </div>
                                         <div class="row checkbox left" style="padding-left: 20px">
@@ -762,12 +762,12 @@
                                 </div>
                                 <div class="row">
                                     <label>Path to Destination Folder</label>
-                                    <input type="text" name="destination_dir" value="${config['dest_dir']}" size="50">
+                                    <input type="text" name="destination_dir" value="${config['destination_dir']}" size="50">
                                     <small>e.g. /Users/name/Music/iTunes or /Volumes/share/music</small>
                                 </div>
                                 <div class="row">
                                     <label>Path to Lossless Destination folder (optional)</label>
-                                    <input type="text" name="lossless_destination_dir" value="${config['lossless_dest_dir']}" size="50">
+                                    <input type="text" name="lossless_destination_dir" value="${config['lossless_destination_dir']}" size="50">
                                     <small>Set this if you have a separate directory for lossless music</small>
                                 </div>
                             </fieldset>
@@ -1258,7 +1258,7 @@
                             </div>
                             <div class="row">
                                 <label>Path to Encoder</label>
-                                <input type="text" name="encoderfolder" value="${config['encoderfolder']}" size="43">
+                                <input type="text" name="encoder_path" value="${config['encoder_path']}" size="43">
                             </div>
                         </td>
                         <td>
@@ -1367,7 +1367,7 @@
                                 <div class="row">
                                     <label>Muscbrainz Mirror</label>
                                     <select name="mirror" id="mirror">
-                                    %for mirror in config['mirror_list']:
+                                    %for mirror in config['mirrorlist']:
                                         <%
                                             if mirror == headphones.CONFIG.MIRROR:
                                                 selected = 'selected="selected"'

--- a/headphones/config.py
+++ b/headphones/config.py
@@ -13,11 +13,13 @@ def bool_int(value):
             value = 0
     return int(bool(value))
 
-_config_definitions = {
+_CONFIG_DEFINITIONS = {
     'ADD_ALBUM_ART': (int, 'General', 0),
     'ADVANCEDENCODER': (str, 'General', ''),
     'ALBUM_ART_FORMAT': (str, 'General', 'folder'),
-    'ALBUM_COMPLETION_PCT': (int, 'Advanced', 80), # This is used in importer.py to determine how complete an album needs to be - to be considered "downloaded". Percentage from 0-100
+    # This is used in importer.py to determine how complete an album needs to
+    # be - to be considered "downloaded". Percentage from 0-100
+    'ALBUM_COMPLETION_PCT': (int, 'Advanced', 80),
     'API_ENABLED': (int, 'General', 0),
     'API_KEY': (str, 'General', ''),
     'AUTOWANT_ALL': (int, 'General', 0),
@@ -237,7 +239,7 @@ class Config(object):
         """ Initialize the config with values from a file """
         self._config_file = config_file
         self._config = ConfigObj(self._config_file, encoding='utf-8')
-        for key in _config_definitions.keys():
+        for key in _CONFIG_DEFINITIONS.keys():
             self.check_setting(key)
         self.ENCODER_MULTICORE_COUNT = max(0, self.ENCODER_MULTICORE_COUNT)
         self._upgrade()
@@ -245,7 +247,7 @@ class Config(object):
     def _define(self, name):
         key = name.upper()
         ini_key = name.lower()
-        definition = _config_definitions[key]
+        definition = _CONFIG_DEFINITIONS[key]
         if len(definition) == 3:
             definition_type, section, default = definition
         else:
@@ -276,8 +278,8 @@ class Config(object):
         new_config = ConfigObj(encoding="UTF-8")
         new_config.filename = self._config_file
 
-        # first copy over everything from the old config, even if it is not correctly
-        # defined to keep from losing data
+        # first copy over everything from the old config, even if it is not
+        # correctly defined to keep from losing data
         for key, subkeys in self._config.items():
             if key not in new_config:
                 new_config[key] = {}
@@ -285,7 +287,7 @@ class Config(object):
                 new_config[key][subkey] = value
 
         # next make sure that everything we expect to have defined is so
-        for key in _config_definitions.keys():
+        for key in _CONFIG_DEFINITIONS.keys():
             key, definition_type, section, ini_key, default = self._define(key)
             self.check_setting(key)
             if section not in new_config:

--- a/headphones/webserve.py
+++ b/headphones/webserve.py
@@ -659,7 +659,7 @@ class WebInterface(object):
 
     def importLastFM(self, username):
         headphones.CONFIG.LASTFM_USERNAME = username
-        headphones.config_write()
+        headphones.CONFIG.write()
         threading.Thread(target=lastfm.getArtists).start()
         raise cherrypy.HTTPRedirect("home")
     importLastFM.exposed = True
@@ -671,7 +671,7 @@ class WebInterface(object):
 
     def importItunes(self, path):
         headphones.CONFIG.PATH_TO_XML = path
-        headphones.config_write()
+        headphones.CONFIG.write()
         threading.Thread(target=importer.itunesImport, args=[path]).start()
         time.sleep(10)
         raise cherrypy.HTTPRedirect("home")
@@ -681,7 +681,7 @@ class WebInterface(object):
         headphones.CONFIG.LIBRARYSCAN = libraryscan
         headphones.CONFIG.AUTO_ADD_ARTISTS = autoadd
         headphones.CONFIG.MUSIC_DIR = path
-        headphones.config_write()
+        headphones.CONFIG.write()
         if scan:
             try:
                 threading.Thread(target=librarysync.libraryScan).start()
@@ -937,9 +937,9 @@ class WebInterface(object):
 
         config = {
             "http_host" : headphones.CONFIG.HTTP_HOST,
-            "http_user" : headphones.CONFIG.HTTP_USERNAME,
+            "http_username" : headphones.CONFIG.HTTP_USERNAME,
             "http_port" : headphones.CONFIG.HTTP_PORT,
-            "http_pass" : headphones.CONFIG.HTTP_PASSWORD,
+            "http_password" : headphones.CONFIG.HTTP_PASSWORD,
             "launch_browser" : checked(headphones.CONFIG.LAUNCH_BROWSER),
             "enable_https" : checked(headphones.CONFIG.ENABLE_HTTPS),
             "https_cert" : headphones.CONFIG.HTTPS_CERT,
@@ -952,21 +952,21 @@ class WebInterface(object):
             "search_interval" : headphones.CONFIG.SEARCH_INTERVAL,
             "libraryscan_interval" : headphones.CONFIG.LIBRARYSCAN_INTERVAL,
             "sab_host" : headphones.CONFIG.SAB_HOST,
-            "sab_user" : headphones.CONFIG.SAB_USERNAME,
-            "sab_api" : headphones.CONFIG.SAB_APIKEY,
-            "sab_pass" : headphones.CONFIG.SAB_PASSWORD,
-            "sab_cat" : headphones.CONFIG.SAB_CATEGORY,
+            "sab_username" : headphones.CONFIG.SAB_USERNAME,
+            "sab_apikey" : headphones.CONFIG.SAB_APIKEY,
+            "sab_password" : headphones.CONFIG.SAB_PASSWORD,
+            "sab_category" : headphones.CONFIG.SAB_CATEGORY,
             "nzbget_host" : headphones.CONFIG.NZBGET_HOST,
-            "nzbget_user" : headphones.CONFIG.NZBGET_USERNAME,
-            "nzbget_pass" : headphones.CONFIG.NZBGET_PASSWORD,
-            "nzbget_cat" : headphones.CONFIG.NZBGET_CATEGORY,
+            "nzbget_username" : headphones.CONFIG.NZBGET_USERNAME,
+            "nzbget_password" : headphones.CONFIG.NZBGET_PASSWORD,
+            "nzbget_category" : headphones.CONFIG.NZBGET_CATEGORY,
             "nzbget_priority" : headphones.CONFIG.NZBGET_PRIORITY,
             "transmission_host" : headphones.CONFIG.TRANSMISSION_HOST,
-            "transmission_user" : headphones.CONFIG.TRANSMISSION_USERNAME,
-            "transmission_pass" : headphones.CONFIG.TRANSMISSION_PASSWORD,
+            "transmission_username" : headphones.CONFIG.TRANSMISSION_USERNAME,
+            "transmission_password" : headphones.CONFIG.TRANSMISSION_PASSWORD,
             "utorrent_host" : headphones.CONFIG.UTORRENT_HOST,
-            "utorrent_user" : headphones.CONFIG.UTORRENT_USERNAME,
-            "utorrent_pass" : headphones.CONFIG.UTORRENT_PASSWORD,
+            "utorrent_username" : headphones.CONFIG.UTORRENT_USERNAME,
+            "utorrent_password" : headphones.CONFIG.UTORRENT_PASSWORD,
             "utorrent_label" : headphones.CONFIG.UTORRENT_LABEL,
             "nzb_downloader_sabnzbd" : radio(headphones.CONFIG.NZB_DOWNLOADER, 0),
             "nzb_downloader_nzbget" : radio(headphones.CONFIG.NZB_DOWNLOADER, 1),
@@ -981,7 +981,7 @@ class WebInterface(object):
             "headphones_indexer" : checked(headphones.CONFIG.HEADPHONES_INDEXER),
             "use_newznab" : checked(headphones.CONFIG.NEWZNAB),
             "newznab_host" : headphones.CONFIG.NEWZNAB_HOST,
-            "newznab_api" : headphones.CONFIG.NEWZNAB_APIKEY,
+            "newznab_apikey" : headphones.CONFIG.NEWZNAB_APIKEY,
             "newznab_enabled" : checked(headphones.CONFIG.NEWZNAB_ENABLED),
             "extra_newznabs" : headphones.CONFIG.get_extra_newznabs(),
             "use_nzbsorg" : checked(headphones.CONFIG.NZBSORG),
@@ -1020,10 +1020,10 @@ class WebInterface(object):
             "pref_qual_1" : radio(headphones.CONFIG.PREFERRED_QUALITY, 1),
             "pref_qual_2" : radio(headphones.CONFIG.PREFERRED_QUALITY, 2),
             "pref_qual_3" : radio(headphones.CONFIG.PREFERRED_QUALITY, 3),
-            "pref_bitrate" : headphones.CONFIG.PREFERRED_BITRATE,
-            "pref_bitrate_high" : headphones.CONFIG.PREFERRED_BITRATE_HIGH_BUFFER,
-            "pref_bitrate_low" : headphones.CONFIG.PREFERRED_BITRATE_LOW_BUFFER,
-            "pref_bitrate_allow_lossless" : checked(headphones.CONFIG.PREFERRED_BITRATE_ALLOW_LOSSLESS),
+            "preferred_bitrate" : headphones.CONFIG.PREFERRED_BITRATE,
+            "preferred_bitrate_high" : headphones.CONFIG.PREFERRED_BITRATE_HIGH_BUFFER,
+            "preferred_bitrate_low" : headphones.CONFIG.PREFERRED_BITRATE_LOW_BUFFER,
+            "preferred_bitrate_allow_lossless" : checked(headphones.CONFIG.PREFERRED_BITRATE_ALLOW_LOSSLESS),
             "detect_bitrate" : checked(headphones.CONFIG.DETECT_BITRATE),
             "lossless_bitrate_from" : headphones.CONFIG.LOSSLESS_BITRATE_FROM,
             "lossless_bitrate_to" : headphones.CONFIG.LOSSLESS_BITRATE_TO,
@@ -1038,8 +1038,8 @@ class WebInterface(object):
             "embed_album_art" : checked(headphones.CONFIG.EMBED_ALBUM_ART),
             "embed_lyrics" : checked(headphones.CONFIG.EMBED_LYRICS),
             "replace_existing_folders" : checked(headphones.CONFIG.REPLACE_EXISTING_FOLDERS),
-            "dest_dir" : headphones.CONFIG.DESTINATION_DIR,
-            "lossless_dest_dir" : headphones.CONFIG.LOSSLESS_DESTINATION_DIR,
+            "destination_dir" : headphones.CONFIG.DESTINATION_DIR,
+            "lossless_destination_dir" : headphones.CONFIG.LOSSLESS_DESTINATION_DIR,
             "folder_format" : headphones.CONFIG.FOLDER_FORMAT,
             "file_format" : headphones.CONFIG.FILE_FORMAT,
             "file_underscores" : checked(headphones.CONFIG.FILE_UNDERSCORES),
@@ -1061,7 +1061,7 @@ class WebInterface(object):
             "encoder":      headphones.CONFIG.ENCODER,
             "xldprofile":   headphones.CONFIG.XLDPROFILE,
             "bitrate":      int(headphones.CONFIG.BITRATE),
-            "encoderfolder":    headphones.CONFIG.ENCODER_PATH,
+            "encoder_path":    headphones.CONFIG.ENCODER_PATH,
             "advancedencoder":  headphones.CONFIG.ADVANCEDENCODER,
             "encoderoutputformat": headphones.CONFIG.ENCODEROUTPUTFORMAT,
             "samplingfrequency": headphones.CONFIG.SAMPLINGFREQUENCY,
@@ -1123,7 +1123,7 @@ class WebInterface(object):
             "boxcar_enabled": checked(headphones.CONFIG.BOXCAR_ENABLED),
             "boxcar_onsnatch": checked(headphones.CONFIG.BOXCAR_ONSNATCH),
             "boxcar_token": headphones.CONFIG.BOXCAR_TOKEN,
-            "mirror_list": headphones.MIRRORLIST,
+            "mirrorlist": headphones.MIRRORLIST,
             "mirror": headphones.CONFIG.MIRROR,
             "customhost": headphones.CONFIG.CUSTOMHOST,
             "customport": headphones.CONFIG.CUSTOMPORT,
@@ -1140,7 +1140,8 @@ class WebInterface(object):
             "mpc_enabled": checked(headphones.CONFIG.MPC_ENABLED)
         }
 
-        # Need to convert EXTRAS to a dictionary we can pass to the config: it'll come in as a string like 2,5,6,8 (append new extras to the end)
+        # Need to convert EXTRAS to a dictionary we can pass to the config:
+        # it'll come in as a string like 2,5,6,8
         extra_munges = {
             "dj-mix": "dj_mix",
             "mixtape/street": "mixtape_street"


### PR DESCRIPTION
Some config data keys were inconsistent. After updating them and reviewing this diff, they don't look like they should have been causing bugs.
Fixed three calls to headphones.config_write()
Made pylint complain less about config.py
