### PR TITLE
Fix for #1998

### DIFF
--- a/headphones/transmission.py
+++ b/headphones/transmission.py
@@ -143,12 +143,12 @@ def torrentAction(method, arguments):
         i = host.rfind(':')
         if i >= 0:
             possible_port = host[i + 1:]
-            host = host + "/rpc"
             try:
                 port = int(possible_port)
                 if port:
                     host = host + "/transmission/rpc"
             except ValueError:
+                host = host + "/rpc"
                 logger.debug('No port, assuming not transmission')
         else:
             logger.error('Transmission port missing')


### PR DESCRIPTION
Moving "rpc" addition to transmission host string after exception
