### PR TITLE
Changed to use python2 to support systems where default python is v3

### DIFF
--- a/Headphones.py
+++ b/Headphones.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #  This file is part of Headphones.
 #
 #  Headphones is free software: you can redistribute it and/or modify

--- a/headphones/searcher_rutracker.py
+++ b/headphones/searcher_rutracker.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # coding=utf-8
 
 # Headphones rutracker.org search

--- a/lib/MultipartPostHandler.py
+++ b/lib/MultipartPostHandler.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 
 ####
 # 06/2010 Nic Wolfe <nic@wolfeden.ca>

--- a/lib/cherrypy/process/servers.py
+++ b/lib/cherrypy/process/servers.py
@@ -54,7 +54,7 @@ CherryPy code
 
 hello.py::
 
-    #!/usr/bin/python
+    #!/usr/bin/env python2
     import cherrypy
 
     class HelloWorld:

--- a/lib/feedparser.py
+++ b/lib/feedparser.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 """Universal feed parser
 
 Handles RSS 0.9x, RSS 1.0, RSS 2.0, CDF, Atom 0.3, and Atom 1.0 feeds

--- a/lib/munkres.py
+++ b/lib/munkres.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: iso-8859-1 -*-
 
 # Documentation is intended to be processed by Epydoc.

--- a/lib/osxnotify/registerapp.py
+++ b/lib/osxnotify/registerapp.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 
 import shutil
 import os
@@ -87,7 +87,7 @@ def registerapp(app):
         f.close()
 
         f = open(app_path + "/Contents/MacOS/main.py", "w")
-        f.write("""#!/usr/bin/python
+        f.write("""#!/usr/bin/env python2
 
 objc = None
 

--- a/lib/pygazelle/api.py
+++ b/lib/pygazelle/api.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 # PyGazelle - https://github.com/cohena/pygazelle
 # A Python implementation of the What.cd Gazelle JSON API

--- a/lib/pynma/__init__.py
+++ b/lib/pynma/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 
 from pynma import PyNMA
 

--- a/lib/pynma/pynma.py
+++ b/lib/pynma/pynma.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 
 from xml.dom.minidom import parseString
 from httplib import HTTPSConnection

--- a/lib/pythontwitter/__init__.py
+++ b/lib/pythontwitter/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 # vim: sw=2 ts=2 sts=2
 #

--- a/lib/pytz/tzfile.py
+++ b/lib/pytz/tzfile.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 '''
 $Id: tzfile.py,v 1.8 2004/06/03 00:15:24 zenzen Exp $
 '''

--- a/lib/requests/certs.py
+++ b/lib/requests/certs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 
 """

--- a/lib/requests/packages/chardet/chardetect.py
+++ b/lib/requests/packages/chardet/chardetect.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 """
 Script which takes one or more file paths and reports on their detected
 encodings


### PR DESCRIPTION
Currently on systems where the default python is v3 (Arch and Fedora for example) headphones fails to run. All linux systems (and updated OS X; not sure about windows) systems should have python2 and python3 binaries as symlinks to the correct versions.
