### PR TITLE
Update pushbullet notification to use JSON

### DIFF
--- a/headphones/notifiers.py
+++ b/headphones/notifiers.py
@@ -444,16 +444,15 @@ class PUSHBULLET(object):
 
         http_handler = HTTPSConnection("api.pushbullet.com")
 
-        data = {'device_iden': headphones.CONFIG.PUSHBULLET_DEVICEID,
-                'type': "note",
+        data = {'type': "note",
                 'title': "Headphones",
                 'body': message.encode("utf-8")}
 
         http_handler.request("POST",
-                                "/api/pushes",
-                                headers={'Content-type': "application/x-www-form-urlencoded",
+                                "/v2/pushes",
+                                headers={'Content-type': "application/json",
                                             'Authorization': 'Basic %s' % base64.b64encode(headphones.CONFIG.PUSHBULLET_APIKEY + ":")},
-                                body=urlencode(data))
+                                body=json.dumps(data))
         response = http_handler.getresponse()
         request_status = response.status
         logger.debug(u"PushBullet response status: %r" % request_status)


### PR DESCRIPTION
The pushbullet api has changed and now only accepts JSON encoded requests. I changed the content-type (line 454) to application/json, and encoded the data using json.dumps. Also, the url for api calls changed as well (line 453). 

Also removed the 'device_iden' (line 447), since it didn't seem to be working correctly. A note on this change...since we aren't specifying a device id in the request, pushbullet will ignore the selected device in the settings page and just send the notification out to every device the user has configured. May want to eventually update the settings page to get a list of devices from pushbullet and use the returned ids here.
