### PR TITLE
Fix for false LMS error reporting

### DIFF
--- a/headphones/notifiers.py
+++ b/headphones/notifiers.py
@@ -290,7 +290,7 @@ class LMS(object):
             return response['result']
         except:
             logger.warn('LMS returned error: %s' % response['error'])
-            return
+            return response['error']
 
     def update(self):
 
@@ -300,7 +300,7 @@ class LMS(object):
             logger.info('Sending library rescan command to LMS @ ' + host)
             request = self._sendjson(host)
 
-            if not request:
+            if request:
                 logger.warn('Error sending rescan request to LMS')
 
 


### PR DESCRIPTION
Got caught up irl and have had no chance to finally nail that false error reporting upon LMS update. Finally done that now.

Merging with Dev so that it can be further merged with master when the time is right, but it's only a 2 line patch based on how LMS responds to JSON requests, so this patch could go straight to prime-time whenever ready.
