### PR TITLE
Active Artist Update can be launched via API

### DIFF
--- a/API.md
+++ b/API.md
@@ -68,6 +68,8 @@ Unmark album as wanted / i.e. mark as skipped
 force search for wanted albums - not launched in a separate thread so it may take a bit to complete
 ### forceProcess
 Force post process albums in download directory - also not launched in a separate thread
+### forceActiveArtistsUpdate
+force Active Artist Update - also not launched in a separate thread
 
 ### getVersion
 Returns some version information: git_path, install_type, current_version, installed_version, commits_behind

--- a/headphones/api.py
+++ b/headphones/api.py
@@ -13,16 +13,17 @@
 #  You should have received a copy of the GNU General Public License
 #  along with Headphones.  If not, see <http://www.gnu.org/licenses/>.
 
-from headphones import db, mb, importer, searcher, cache, postprocessor, versioncheck, logger
+from headphones import db, mb, updater, importer, searcher, cache, postprocessor, versioncheck, logger
 
 import headphones
 import json
 
 cmd_list = ['getIndex', 'getArtist', 'getAlbum', 'getUpcoming', 'getWanted', 'getSimilar', 'getHistory', 'getLogs',
             'findArtist', 'findAlbum', 'addArtist', 'delArtist', 'pauseArtist', 'resumeArtist', 'refreshArtist',
-            'addAlbum', 'queueAlbum', 'unqueueAlbum', 'forceSearch', 'forceProcess', 'getVersion', 'checkGithub',
-            'shutdown', 'restart', 'update', 'getArtistArt', 'getAlbumArt', 'getArtistInfo', 'getAlbumInfo',
-            'getArtistThumb', 'getAlbumThumb', 'choose_specific_download', 'download_specific_release']
+            'addAlbum', 'queueAlbum', 'unqueueAlbum', 'forceSearch', 'forceProcess', 'forceActiveArtistsUpdate', 
+            'getVersion', 'checkGithub','shutdown', 'restart', 'update', 'getArtistArt', 'getAlbumArt', 
+            'getArtistInfo', 'getAlbumInfo', 'getArtistThumb', 'getAlbumThumb', 
+            'choose_specific_download', 'download_specific_release']
 
 
 class Api(object):
@@ -320,6 +321,9 @@ class Api(object):
         if 'dir' in kwargs:
             self.dir = kwargs['dir']
         postprocessor.forcePostProcess(self.dir)
+
+    def _forceActiveArtistsUpdate(self, **kwargs):
+        updater.dbUpdate()
 
     def _getVersion(self, **kwargs):
         self.data = {


### PR DESCRIPTION
Added an API command to launch an Active Artist Update.  Personally, I would like to do this once a week on at a set time via cron as opposed to it being based on the time delta from when Headphones was started.