### PR TITLE
Adding a regex to capture lyrics.wikia.com's new/different way of showing lyrics

### DIFF
--- a/headphones/lyrics.py
+++ b/headphones/lyrics.py
@@ -49,6 +49,9 @@ def getLyrics(artist, song):
     m = re.compile('''<div class='lyricbox'><div class='rtMatcher'>.*?</div>(.*?)<!--''').search(lyricspage)
 
     if not m:
+        m = re.compile('''<div class='lyricbox'><script>.*</script>(.*?)<!--''').search(lyricspage)
+
+    if not m:
         m = re.compile('''<div class='lyricbox'><span style="padding:1em"><a href="/Category:Instrumental" title="Instrumental">''').search(lyricspage)
         if m:
             return u'(Instrumental)'


### PR DESCRIPTION
I was running into issues with Headphones scraping lyrics. I'm not sure if lyrics.wikia.com changed their format entirely or if it's just on the few albums I've tried.

This additional regular expression has been successful at grabbing the lyrics for a couple of albums for me so far.