### PR TITLE
Added the option to provide an extension when using 'Advanced Encoding'

### DIFF
--- a/data/interfaces/default/config.html
+++ b/data/interfaces/default/config.html
@@ -1403,6 +1403,11 @@
                                 </div>
                             </div>
                             <div class="row">
+                                <label>Extension</label>
+                                <input type="text" name="encoderoutputformat" value="${config['encoderoutputformat']}" size="43">
+                                <small>If different from format selected above</small>
+                            </div>
+                            <div class="row">
                                 <label>Path to Encoder</label>
                                 <input type="text" name="encoder_path" value="${config['encoder_path']}" size="43">
                             </div>

--- a/headphones/music_encoder.py
+++ b/headphones/music_encoder.py
@@ -128,7 +128,7 @@ def encode(albumPath):
                     logger.warn('Cannot re-encode .ogg %s', music.decode(headphones.SYS_ENCODING, 'replace'))
                 else:
                     encode = True
-            elif headphones.CONFIG.ENCODEROUTPUTFORMAT == 'mp3' or headphones.CONFIG.ENCODEROUTPUTFORMAT == 'm4a':
+            else:
                 if music.decode(headphones.SYS_ENCODING, 'replace').lower().endswith('.' + headphones.CONFIG.ENCODEROUTPUTFORMAT) and (int(infoMusic.bitrate / 1000) <= headphones.CONFIG.BITRATE):
                     logger.info('%s has bitrate <= %skb, will not be re-encoded', music, headphones.CONFIG.BITRATE)
                 else:

--- a/headphones/webserve.py
+++ b/headphones/webserve.py
@@ -1309,6 +1309,12 @@ class WebInterface(object):
             kwargs[plain_config] = kwargs[use_config]
             del kwargs[use_config]
 
+        # Check if encoderoutputformat is set multiple times
+        if len(kwargs['encoderoutputformat'][-1]) > 1:
+            kwargs['encoderoutputformat'] = kwargs['encoderoutputformat'][-1]
+        else:
+            kwargs['encoderoutputformat'] = kwargs['encoderoutputformat'][0]
+
         extra_newznabs = []
         for kwarg in [x for x in kwargs if x.startswith('newznab_host')]:
             newznab_host_key = kwarg


### PR DESCRIPTION
The settings in the 'Advanced Encoding Options' section still use the extension of the format selected in the 'Audio Properties' section. For instance when you give the custom argument '-y -acodec flac' while the mp3 format is selected in the 'Audio Properties' section the resulting files will still have the .mp3 extension.

The variable headphones.CONFIG.ENCODEROUTPUTFORMAT is set by the format selected in  'Audio Properties'. With these changes a provided extension in the 'Advanced Encoding Options' section takes precedence.
