### PR TITLE
postprocessor: use a temporary folder

### DIFF
--- a/headphones/postprocessor.py
+++ b/headphones/postprocessor.py
@@ -21,6 +21,7 @@ import beets
 import threading
 import itertools
 import headphones
+import tempfile
 
 from beets import autotag
 from beets import config as beetsconfig
@@ -279,16 +280,18 @@ def verify(albumid, albumpath, Kind=None, forced=False, keep_original_folder=Fal
 def doPostProcessing(albumid, albumpath, release, tracks, downloaded_track_list, Kind=None, keep_original_folder=False):
 
     logger.info('Starting post-processing for: %s - %s' % (release['ArtistName'], release['AlbumTitle']))
+    new_folder = None
     # Check to see if we're preserving the torrent dir
     if (headphones.CONFIG.KEEP_TORRENT_FILES and Kind == "torrent" and 'headphones-modified' not in albumpath) or headphones.CONFIG.KEEP_ORIGINAL_FOLDER or keep_original_folder:
-        new_folder = os.path.join(albumpath, 'headphones-modified'.encode(headphones.SYS_ENCODING, 'replace'))
-        logger.info("Copying files to 'headphones-modified' subfolder to preserve downloaded files for seeding")
+        new_folder = os.path.join(tempfile.mkdtemp(prefix="headphones_"), "headphones")
+        logger.info("Copying files to " + new_folder.decode(headphones.SYS_ENCODING, 'replace') + " subfolder to preserve downloaded files for seeding")
         try:
             shutil.copytree(albumpath, new_folder)
             # Update the album path with the new location
             albumpath = new_folder
         except Exception as e:
             logger.warn("Cannot copy/move files to temp folder: " + new_folder.decode(headphones.SYS_ENCODING, 'replace') + ". Not continuing. Error: " + str(e))
+            shutil.rmtree(new_folder)
             return
 
         # Need to update the downloaded track list with the new location.
@@ -316,6 +319,8 @@ def doPostProcessing(albumid, albumpath, release, tracks, downloaded_track_list,
             return
         except IOError:
             logger.error("Unable to find media file: %s. Not continuing.")
+            if new_folder:
+                shutil.rmtree(new_folder)
             return
 
         # If one of the options below is set, it will access/touch/modify the
@@ -334,6 +339,8 @@ def doPostProcessing(albumid, albumpath, release, tracks, downloaded_track_list,
                 logger.error("Track file is not writable. This is required " \
                     "for some post processing steps: %s. Not continuing.",
                     downloaded_track.decode(headphones.SYS_ENCODING, "replace"))
+                if new_folder:
+                    shutil.rmtree(new_folder)
                 return
 
     #start encoding
@@ -341,6 +348,8 @@ def doPostProcessing(albumid, albumpath, release, tracks, downloaded_track_list,
         downloaded_track_list = music_encoder.encode(albumpath)
 
         if not downloaded_track_list:
+            if new_folder:
+                shutil.rmtree(new_folder)
             return
 
     artwork = None
@@ -374,6 +383,8 @@ def doPostProcessing(albumid, albumpath, release, tracks, downloaded_track_list,
     if headphones.CONFIG.CORRECT_METADATA:
         correctedMetadata = correctMetadata(albumid, release, downloaded_track_list)
         if not correctedMetadata and headphones.CONFIG.DO_NOT_PROCESS_UNMATCHED:
+            if new_folder:
+                shutil.rmtree(new_folder)
             return
 
     if headphones.CONFIG.EMBED_LYRICS:
@@ -515,6 +526,9 @@ def doPostProcessing(albumid, albumpath, release, tracks, downloaded_track_list,
         email = notifiers.Email()
         subject = release['ArtistName'] + ' - ' + release['AlbumTitle']
         email.notify(subject, "Download and Postprocessing completed")
+
+    if new_folder:
+        shutil.rmtree(new_folder)
 
 
 def embedAlbumArt(artwork, downloaded_track_list):


### PR DESCRIPTION
Hello,

When doing the post-processing, in case headphones cannot write in the downloads folder, the sub-folder with "headphones-modified" cannot be created. Instead of using a subfolder, prefer a temporary folder as provided by the tempfile utility. That way, even if the folder is read-only, we can do post-processing.