### PR TITLE
Initial commit to remove upcoming albums from wanted list

### DIFF
--- a/headphones/api.py
+++ b/headphones/api.py
@@ -162,12 +162,12 @@ class Api(object):
 
     def _getUpcoming(self, **kwargs):
         self.data = self._dic_from_query(
-            "SELECT * from albums WHERE ReleaseDate > date('now') order by ReleaseDate DESC")
+            "SELECT * from albums WHERE ReleaseDate > date('now') order by ReleaseDate ASC")
         return
 
     def _getWanted(self, **kwargs):
         self.data = self._dic_from_query(
-            "SELECT * from albums WHERE Status='Wanted'")
+            "SELECT * from albums WHERE Status='Wanted' and ReleaseDate <= date ('now') order by ReleaseDate DESC")
         return
 
     def _getSnatched(self, **kwargs):

--- a/headphones/webserve.py
+++ b/headphones/webserve.py
@@ -531,7 +531,8 @@ class WebInterface(object):
         myDB = db.DBConnection()
         upcoming = myDB.select(
             "SELECT * from albums WHERE ReleaseDate > date('now') order by ReleaseDate ASC")
-        wanted = myDB.select("SELECT * from albums WHERE Status='Wanted'")
+        wanted = myDB.select(
+            "SELECT * from albums WHERE Status='Wanted' and ReleaseDate <= date ('now') order by ReleaseDate DESC)
         return serve_template(templatename="upcoming.html", title="Upcoming", upcoming=upcoming,
                               wanted=wanted)
 


### PR DESCRIPTION
I think this needs some discussion. Sickrage does the job correct. Every upcoming episode is 'unaired'. An episode is 'wanted' if it is aired. We should do the same with music albums:

- album is 'upcoming' if release date is < date(now) instead of 'wanted'
- album changes to 'wanted' if release date >= date(now) and user checked 'Automatically mark upcoming albums as wanted'
- album changes to 'skipped' if release date >= date(now) and user did not checked 'Automatically mark upcoming albums as wanted'
- still search for an album if 'Automatically mark upcoming albums as wanted' is checked and 'Wait until an album's release date before searching' is not checked, because often music albums are available before release date (in contrast to tv)

Of course, if we want it like this I need to extend this pull. Any thoughts?