### PR TITLE
Fix misplaced quote mark in init.ubuntu

### DIFF
--- a/init-scripts/init.ubuntu
+++ b/init-scripts/init.ubuntu
@@ -164,7 +164,7 @@ start_headphones () {
     handle_updates
     if ! is_running; then
         log_daemon_msg "Starting $DESC"
-        start-stop-daemon -o -d "$APP_PATH" -c "$RUN_AS" --start $EXTRA_SSD_OPTS --pidfile "$PID_FILE" --exec "$DAEMON" -- "$DAEMON_OPTS"
+        start-stop-daemon -o -d "$APP_PATH" -c "$RUN_AS" --start $EXTRA_SSD_OPTS --pidfile "$PID_FILE" --exec "$DAEMON" -- $DAEMON_OPTS
         check_retval
     else
         log_success_msg "$DESC: already running (pid $PID)"

--- a/init-scripts/init.ubuntu
+++ b/init-scripts/init.ubuntu
@@ -164,7 +164,7 @@ start_headphones () {
     handle_updates
     if ! is_running; then
         log_daemon_msg "Starting $DESC"
-        start-stop-daemon -o -d "$APP_PATH" -c "$RUN_AS" --start "$EXTRA_SSD"_OPTS --pidfile "$PID_FILE" --exec "$DAEMON" -- "$DAEMON_OPTS"
+        start-stop-daemon -o -d "$APP_PATH" -c "$RUN_AS" --start "$EXTRA_SSD_OPTS" --pidfile "$PID_FILE" --exec "$DAEMON" -- "$DAEMON_OPTS"
         check_retval
     else
         log_success_msg "$DESC: already running (pid $PID)"

--- a/init-scripts/init.ubuntu
+++ b/init-scripts/init.ubuntu
@@ -164,7 +164,7 @@ start_headphones () {
     handle_updates
     if ! is_running; then
         log_daemon_msg "Starting $DESC"
-        start-stop-daemon -o -d "$APP_PATH" -c "$RUN_AS" --start "$EXTRA_SSD_OPTS" --pidfile "$PID_FILE" --exec "$DAEMON" -- "$DAEMON_OPTS"
+        start-stop-daemon -o -d "$APP_PATH" -c "$RUN_AS" --start $EXTRA_SSD_OPTS --pidfile "$PID_FILE" --exec "$DAEMON" -- "$DAEMON_OPTS"
         check_retval
     else
         log_success_msg "$DESC: already running (pid $PID)"


### PR DESCRIPTION
This just fixes some regressions introduced to ubuntu startup script in the latest update