### PR TITLE
Make travis builds faster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@
 # http://about.travis-ci.org/docs/
 
 language: python
+sudo: false
 
 # Available Python versions:
 # http://about.travis-ci.org/docs/user/ci-environment/#Python-VM-images


### PR DESCRIPTION
Headphones does not require a full virtual machine, it can run using 
Travis-CI's container infrastructure which has higher limits and is 
faster

See https://docs.travis-ci.com/user/workers/container-based-infrastructure/ for more info