### PR TITLE
webserve.py: Fix scanning artists with non-ASCII letters in dir name.

### DIFF
--- a/headphones/webserve.py
+++ b/headphones/webserve.py
@@ -343,7 +343,7 @@ class WebInterface(object):
 
         for dir in dirs:
             artistfolder = os.path.join(dir, folder)
-            if not os.path.isdir(artistfolder):
+            if not os.path.isdir(artistfolder.encode(headphones.SYS_ENCODING)):
                 logger.debug("Cannot find directory: " + artistfolder)
                 continue
             threading.Thread(target=librarysync.libraryScan,


### PR DESCRIPTION
This patch prevents exceptions from os.path.isdir() called with unicode folder names.