### PR TITLE
helpers.py: Fix replace_all() broken by commit not in sync

### DIFF
--- a/headphones/helpers.py
+++ b/headphones/helpers.py
@@ -207,7 +207,7 @@ def replace_all(text, dic, normalize=False):
                 j = unicodedata.normalize('NFC', j.decode(headphones.SYS_ENCODING, 'replace'))
             new_dic[i] = j
         dic = new_dic
-    return pathrender.render(text, dic)
+    return pathrender.render(text, dic)[0]
 
 
 def replace_illegal_chars(string, type="file"):


### PR DESCRIPTION
@rembo10 : I just noticed that the pathrender commit was not synced with the most recent change in helpers.py which was now failing, this is a quick fix for that, sorry for the trouble.