### PR TITLE
helpers: Replace cleanName() implementation to get much higher match ratio.

### DIFF
--- a/headphones/helpers_test.py
+++ b/headphones/helpers_test.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+from unittestcompat import TestCase
+from headphones.helpers import clean_name
+
+
+class HelpersTest(TestCase):
+
+    def test_clean_name(self):
+        """helpers: check correctness of clean_name() function"""
+        cases = {
+            u' Weiße & rose ': 'Weisse and rose',
+            u'Multiple / spaces': 'Multiple spaces',
+            u'Kevin\'s m²': 'Kevins m2',
+            u'Symphonęy Nº9': 'Symphoney No.9',
+            u'ÆæßðÞĲĳ': u'AeaessdThIJıj',
+            u'Obsessió (Cerebral Apoplexy remix)': 'obsessio cerebral '
+                                                    'apoplexy remix',
+            u'Doktór Hałabała i siedmiu zbojów': 'doktor halabala i siedmiu '
+                                                 'zbojow',
+            u'Arbetets Söner och Döttrar': 'arbetets soner och dottrar',
+            u'Björk Guðmundsdóttir': 'bjork gudmundsdottir',
+            u'L\'Arc~en~Ciel': 'larc en ciel',
+            u'Orquesta de la Luz (オルケスタ・デ・ラ・ルス)':
+                u'Orquesta de la Luz オルケスタ デ ラ ルス'
+
+        }
+        for first, second in cases.iteritems():
+            nf = clean_name(first).lower()
+            ns = clean_name(second).lower()
+            self.assertEqual(
+                nf, ns, u"check cleaning of case (%s,"
+                        u"%s)" % (nf, ns)
+            )
+
+    def test_clean_name_nonunicode(self):
+        """helpers: check if clean_name() works on non-unicode input"""
+        input = 'foo $ bar/BAZ'
+        test = clean_name(input).lower()
+        expected = 'foo bar baz'
+        self.assertEqual(
+            test, expected, "check clean_name() works on non-unicode"
+        )
+        input = 'fóó $ BAZ'
+        test = clean_name(input).lower()
+        expected = clean_name('%fóó baz ').lower()
+        self.assertEqual(
+            test, expected, "check clean_name() with narrow non-ascii input"
+        )

--- a/headphones/importer.py
+++ b/headphones/importer.py
@@ -374,7 +374,7 @@ def addArtisttoDB(artistid, extrasonly=False, forcefull=False, type="artist"):
 
             for track in hybridrelease['Tracks']:
 
-                cleanname = helpers.cleanName(
+                cleanname = helpers.clean_name(
                     artist['artist_name'] + ' ' + rg['title'] + ' ' + track['title'])
 
                 controlValueDict = {"TrackID": track['id'],
@@ -710,7 +710,7 @@ def addReleaseById(rid, rgid=None):
         myDB.action('INSERT INTO releases VALUES( ?, ?)', [rid, release_dict['rgid']])
 
         for track in release_dict['tracks']:
-            cleanname = helpers.cleanName(
+            cleanname = helpers.clean_name(
                 release_dict['artist_name'] + ' ' + release_dict['rg_title'] + ' ' + track['title'])
 
             controlValueDict = {"TrackID": track['id'],

--- a/headphones/librarysync.py
+++ b/headphones/librarysync.py
@@ -138,7 +138,7 @@ def libraryScan(dir=None, append=False, ArtistID=None, ArtistName=None,
                 # TODO: skip adding songs without the minimum requisite information (just a matter of putting together the right if statements)
 
                 if f_artist and f.album and f.title:
-                    CleanName = helpers.cleanName(f_artist + ' ' + f.album + ' ' + f.title)
+                    CleanName = helpers.clean_name(f_artist + ' ' + f.album + ' ' + f.title)
                 else:
                     CleanName = None
 
@@ -332,15 +332,15 @@ def libraryScan(dir=None, append=False, ArtistID=None, ArtistName=None,
         # There was a bug where artists with special characters (-,') would show up in new artists.
         artist_list = [
             x for x in unique_artists
-            if helpers.cleanName(x).lower() not in [
-                helpers.cleanName(y[0]).lower()
+            if helpers.clean_name(x).lower() not in [
+                helpers.clean_name(y[0]).lower()
                 for y in current_artists
                 ]
             ]
         artists_checked = [
             x for x in unique_artists
-            if helpers.cleanName(x).lower() in [
-                helpers.cleanName(y[0]).lower()
+            if helpers.clean_name(x).lower() in [
+                helpers.clean_name(y[0]).lower()
                 for y in current_artists
                 ]
             ]

--- a/headphones/mb.py
+++ b/headphones/mb.py
@@ -637,7 +637,7 @@ def get_new_releases(rgid, includeExtras=False, forcefull=False):
 
             for track in release['Tracks']:
 
-                cleanname = helpers.cleanName(
+                cleanname = helpers.clean_name(
                     release['ArtistName'] + ' ' + release['AlbumTitle'] + ' ' + track['title'])
 
                 controlValueDict = {"TrackID": track['id'],

--- a/headphones/postprocessor.py
+++ b/headphones/postprocessor.py
@@ -610,16 +610,23 @@ def addAlbumArt(artwork, albumpath, release):
     logger.info('Adding album art to folder')
 
     try:
-        year = release['ReleaseDate'][:4]
+        date = release['ReleaseDate']
     except TypeError:
-        year = ''
+        date = u''
+
+    if date is not None:
+        year = date[:4]
+    else:
+        year = u''
 
     values = {'$Artist': release['ArtistName'],
               '$Album': release['AlbumTitle'],
               '$Year': year,
+              '$Date': date,
               '$artist': release['ArtistName'].lower(),
               '$album': release['AlbumTitle'].lower(),
-              '$year': year
+              '$year': year,
+              '$date': date
               }
 
     album_art_name = helpers.replace_all(headphones.CONFIG.ALBUM_ART_FORMAT.strip(),
@@ -679,7 +686,12 @@ def moveFiles(albumpath, release, tracks):
         date = release['ReleaseDate']
     except TypeError:
         date = u''
-    year = date[:4]
+
+    if date is not None:
+        year = date[:4]
+    else:
+        year = u''
+
     artist = release['ArtistName'].replace('/', '_')
     album = release['AlbumTitle'].replace('/', '_')
     if headphones.CONFIG.FILE_UNDERSCORES:
@@ -1072,7 +1084,11 @@ def renameFiles(albumpath, downloaded_track_list, release):
         date = release['ReleaseDate']
     except TypeError:
         date = u''
-    year = date[:4]
+
+    if date is not None:
+        year = date[:4]
+    else:
+        year = u''
 
     # Until tagging works better I'm going to rely on the already provided metadata
 

--- a/headphones/webserve.py
+++ b/headphones/webserve.py
@@ -29,7 +29,7 @@ import urllib2
 import os
 import re
 from headphones import logger, searcher, db, importer, mb, lastfm, librarysync, helpers, notifiers
-from headphones.helpers import checked, radio, today, cleanName
+from headphones.helpers import checked, radio, today, clean_name
 from mako.lookup import TemplateLookup
 from mako import exceptions
 import headphones
@@ -577,7 +577,7 @@ class WebInterface(object):
         for albums in have_albums:
             # Have to skip over manually matched tracks
             if albums['ArtistName'] and albums['AlbumTitle'] and albums['TrackTitle']:
-                original_clean = helpers.cleanName(
+                original_clean = helpers.clean_name(
                     albums['ArtistName'] + " " + albums['AlbumTitle'] + " " + albums['TrackTitle'])
                 # else:
                 #     original_clean = None
@@ -595,10 +595,12 @@ class WebInterface(object):
         # unmatchedalbums = [f for f in have_album_dictionary if f not in [x for x in headphones_album_dictionary]]
 
         check = set(
-            [(cleanName(d['ArtistName']).lower(), cleanName(d['AlbumTitle']).lower()) for d in
+            [(clean_name(d['ArtistName']).lower(),
+              clean_name(d['AlbumTitle']).lower()) for d in
              headphones_album_dictionary])
         unmatchedalbums = [d for d in have_album_dictionary if (
-        cleanName(d['ArtistName']).lower(), cleanName(d['AlbumTitle']).lower()) not in check]
+            clean_name(d['ArtistName']).lower(),
+            clean_name(d['AlbumTitle']).lower()) not in check]
 
         return serve_template(templatename="manageunmatched.html", title="Manage Unmatched Items",
                               unmatchedalbums=unmatchedalbums)
@@ -622,8 +624,8 @@ class WebInterface(object):
                 (artist, album))
 
         elif action == "matchArtist":
-            existing_artist_clean = helpers.cleanName(existing_artist).lower()
-            new_artist_clean = helpers.cleanName(new_artist).lower()
+            existing_artist_clean = helpers.clean_name(existing_artist).lower()
+            new_artist_clean = helpers.clean_name(new_artist).lower()
             if new_artist_clean != existing_artist_clean:
                 have_tracks = myDB.action(
                     'SELECT Matched, CleanName, Location, BitRate, Format FROM have WHERE ArtistName=?',
@@ -668,10 +670,10 @@ class WebInterface(object):
                     "Artist %s already named appropriately; nothing to modify" % existing_artist)
 
         elif action == "matchAlbum":
-            existing_artist_clean = helpers.cleanName(existing_artist).lower()
-            new_artist_clean = helpers.cleanName(new_artist).lower()
-            existing_album_clean = helpers.cleanName(existing_album).lower()
-            new_album_clean = helpers.cleanName(new_album).lower()
+            existing_artist_clean = helpers.clean_name(existing_artist).lower()
+            new_artist_clean = helpers.clean_name(new_artist).lower()
+            existing_album_clean = helpers.clean_name(existing_album).lower()
+            new_album_clean = helpers.clean_name(new_album).lower()
             existing_clean_string = existing_artist_clean + " " + existing_album_clean
             new_clean_string = new_artist_clean + " " + new_album_clean
             if existing_clean_string != new_clean_string:
@@ -728,7 +730,7 @@ class WebInterface(object):
             'SELECT ArtistName, AlbumTitle, TrackTitle, CleanName, Matched from have')
         for albums in manualalbums:
             if albums['ArtistName'] and albums['AlbumTitle'] and albums['TrackTitle']:
-                original_clean = helpers.cleanName(
+                original_clean = helpers.clean_name(
                     albums['ArtistName'] + " " + albums['AlbumTitle'] + " " + albums['TrackTitle'])
                 if albums['Matched'] == "Ignored" or albums['Matched'] == "Manual" or albums[
                     'CleanName'] != original_clean:
@@ -769,7 +771,7 @@ class WebInterface(object):
                 [artist])
             update_count = 0
             for tracks in update_clean:
-                original_clean = helpers.cleanName(
+                original_clean = helpers.clean_name(
                     tracks['ArtistName'] + " " + tracks['AlbumTitle'] + " " + tracks[
                         'TrackTitle']).lower()
                 album = tracks['AlbumTitle']
@@ -797,7 +799,7 @@ class WebInterface(object):
                 (artist, album))
             update_count = 0
             for tracks in update_clean:
-                original_clean = helpers.cleanName(
+                original_clean = helpers.clean_name(
                     tracks['ArtistName'] + " " + tracks['AlbumTitle'] + " " + tracks[
                         'TrackTitle']).lower()
                 track_title = tracks['TrackTitle']


### PR DESCRIPTION
Track matching is performed using 'CleanName' which up to now was obtained in
convoluted way, which effectively removed any non-ascii alphanumeric characters
but at the same time left some trash preventing the names to be matched due to
whitespace differences. Current implementation allows for differentiation based
on unicode characters (which are normalized beforehand), but at the same time
allows only alphanumeric chars to be taken into account and coalesces remaining
spaces. Based on observations on several-tens GiB library, this allows for much
better ratio of automatic track matches.