### PR TITLE
Deluge Improvements and Fixes

### DIFF
--- a/data/interfaces/default/config.html
+++ b/data/interfaces/default/config.html
@@ -396,7 +396,7 @@
                                     <label>Deluge SSL Certificate</label>
                                     <input type="text" name="deluge_cert" value="${config['deluge_cert']}" size="30">
                                     <small>Path to the certificate file. Make sure to use a valid certificate ("Issued To" field must match 
-                                        hostname).</small>
+                                        hostname) which is <em>not</em> the case with the default certificate. Path is usually <span style="font-family: monospace;">%appdata%\deluge\ssl</span> on Windows, <span style="font-family: monospace;">~/.config/deluge/ssl/</span> on Linux.</small>
                                 </div>
                                 <div class="row">
                                     <label>Deluge Password</label>

--- a/data/interfaces/default/config.html
+++ b/data/interfaces/default/config.html
@@ -396,7 +396,7 @@
                                     <label>Deluge SSL Certificate</label>
                                     <input type="text" name="deluge_cert" value="${config['deluge_cert']}" size="30">
                                     <small>Path to the certificate file. Make sure to use a valid certificate ("Issued To" field must match 
-                                        hostname) which is <em>not</em> the case with the default certificate. Path is usually <span style="font-family: monospace;">%appdata%\deluge\ssl</span> on Windows, <span style="font-family: monospace;">~/.config/deluge/ssl/</span> on Linux.</small>
+                                        hostname) which is <em>not</em> the case with the default certificate. Path is usually <span style="font-family: monospace;">%appdata%\deluge\ssl</span> on Windows, <span style="font-family: monospace;">~/.config/deluge/ssl/</span> on Linux. Leave this blank if you are using a self-signed certificate.</small>
                                 </div>
                                 <div class="row">
                                     <label>Deluge Password</label>

--- a/data/interfaces/default/config.html
+++ b/data/interfaces/default/config.html
@@ -393,6 +393,12 @@
                                     <small>Usually http://localhost:8112 (requires WebUI plugin)</small>
                                 </div>
                                 <div class="row">
+                                    <label>Deluge SSL Certificate</label>
+                                    <input type="text" name="deluge_cert" value="${config['deluge_cert']}" size="30">
+                                    <small>Path to the certificate file. Make sure to use a valid certificate ("Issued To" field must match 
+                                        hostname).</small>
+                                </div>
+                                <div class="row">
                                     <label>Deluge Password</label>
                                     <input type="password" name="deluge_password" value="${config['deluge_password']}" size="30">
                                 </div>

--- a/headphones/__init__.py
+++ b/headphones/__init__.py
@@ -143,7 +143,7 @@ def initialize(config_file):
             SOFT_CHROOT = SoftChroot(str(CONFIG.SOFT_CHROOT))
             if SOFT_CHROOT.isEnabled():
                 logger.info("Soft-chroot enabled for dir: %s", str(CONFIG.SOFT_CHROOT))
-        except exceptions.SoftChrootError as e:
+        except headphones.exceptions.SoftChrootError as e:
             logger.error("SoftChroot error: %s", e)
             raise e
 

--- a/headphones/config.py
+++ b/headphones/config.py
@@ -68,6 +68,7 @@ _CONFIG_DEFINITIONS = {
     'CUSTOMUSER': (str, 'General', ''),
     'DELETE_LOSSLESS_FILES': (int, 'General', 1),
     'DELUGE_HOST': (str, 'Deluge', ''),
+    'DELUGE_CERT': (str, 'Deluge', ''),
     'DELUGE_PASSWORD': (str, 'Deluge', ''),
     'DELUGE_LABEL': (str, 'Deluge', ''),
     'DELUGE_DONE_DIRECTORY': (str, 'Deluge', ''),

--- a/headphones/deluge.py
+++ b/headphones/deluge.py
@@ -60,8 +60,10 @@ def _scrubber(text):
             text = re.sub('\:\/\/.*\:' , '://REMOVED:' , text)
             # Session cookie
             text = re.sub("_session_id'\: '.*'", "_session_id': 'REMOVED'", text)
-            # Local Windows path
-            # TODO
+            # Local Windows user path
+            if text.lower().startswith('c:\\users\\'):
+                k = text.split('\\')
+                text = '\\'.join([k[0], k[1], '.....', k[-1]])
             #partial_link = re.sub('(auth.*?)=.*&','\g<1>=SECRETZ&', link)
             #partial_link = re.sub('(\w)=[0-9a-zA-Z]*&*','\g<1>=REMOVED&', link)
         except Exception as e:

--- a/headphones/deluge.py
+++ b/headphones/deluge.py
@@ -72,7 +72,7 @@ def _scrubber(text):
     return text
 
 
-def addTorrent(link, data=None):
+def addTorrent(link, data=None, name=None):
     try:
         # Authenticate anyway
         logger.debug('Deluge: addTorrent Authentication')
@@ -121,19 +121,20 @@ def addTorrent(link, data=None):
             if 'announce' not in str(torrentfile)[:40]:
                 logger.debug('Deluge: Contents of %s doesn\'t look like a torrent file' % _scrubber(link))
                 return False
-            # Extract torrent name from .torrent
-            try:
-                logger.debug('Deluge: Getting torrent name length')
-                name_length = int(re.findall('name([0-9]*)\:.*?\:', str(torrentfile))[0])
-                logger.debug('Deluge: Getting torrent name')
-                name = re.findall('name[0-9]*\:(.*?)\:', str(torrentfile))[0][:name_length]
-            except Exception as e:
-                logger.debug('Deluge: Could not get torrent name, getting file name')
-                # get last part of link/path (name only)
-                name = link.split('\\')[-1].split('/')[-1]
-                # remove '.torrent' suffix
-                if name[-len('.torrent'):] == '.torrent':
-                    name = name[:-len('.torrent')]
+            if not name:
+                # Extract torrent name from .torrent
+                try:
+                    logger.debug('Deluge: Getting torrent name length')
+                    name_length = int(re.findall('name([0-9]*)\:.*?\:', str(torrentfile))[0])
+                    logger.debug('Deluge: Getting torrent name')
+                    name = re.findall('name[0-9]*\:(.*?)\:', str(torrentfile))[0][:name_length]
+                except Exception as e:
+                    logger.debug('Deluge: Could not get torrent name, getting file name')
+                    # get last part of link/path (name only)
+                    name = link.split('\\')[-1].split('/')[-1]
+                    # remove '.torrent' suffix
+                    if name[-len('.torrent'):] == '.torrent':
+                        name = name[:-len('.torrent')]
             logger.debug('Deluge: Sending Deluge torrent with name %s and content [%s...]' % (name, str(torrentfile)[:40]))
             result = {'type': 'torrent',
                         'name': name,
@@ -149,19 +150,20 @@ def addTorrent(link, data=None):
                 logger.debug('Deluge: Getting .torrent file')
                 with open(link, 'rb') as f:
                     torrentfile = f.read()
-            # Extract torrent name from .torrent
-            try:
-                logger.debug('Deluge: Getting torrent name length')
-                name_length = int(re.findall('name([0-9]*)\:.*?\:', str(torrentfile))[0])
-                logger.debug('Deluge: Getting torrent name')
-                name = re.findall('name[0-9]*\:(.*?)\:', str(torrentfile))[0][:name_length]
-            except Exception as e:
-                logger.debug('Deluge: Could not get torrent name, getting file name')
-                # get last part of link/path (name only)
-                name = link.split('\\')[-1].split('/')[-1]
-                # remove '.torrent' suffix
-                if name[-len('.torrent'):] == '.torrent':
-                    name = name[:-len('.torrent')]
+            if not name:
+                # Extract torrent name from .torrent
+                try:
+                    logger.debug('Deluge: Getting torrent name length')
+                    name_length = int(re.findall('name([0-9]*)\:.*?\:', str(torrentfile))[0])
+                    logger.debug('Deluge: Getting torrent name')
+                    name = re.findall('name[0-9]*\:(.*?)\:', str(torrentfile))[0][:name_length]
+                except Exception as e:
+                    logger.debug('Deluge: Could not get torrent name, getting file name')
+                    # get last part of link/path (name only)
+                    name = link.split('\\')[-1].split('/')[-1]
+                    # remove '.torrent' suffix
+                    if name[-len('.torrent'):] == '.torrent':
+                        name = name[:-len('.torrent')]
             logger.debug('Deluge: Sending Deluge torrent with name %s and content [%s...]' % (name, str(torrentfile)[:40]))
             result = {'type': 'torrent',
                         'name': name,

--- a/headphones/deluge.py
+++ b/headphones/deluge.py
@@ -72,16 +72,20 @@ def addTorrent(link, data=None):
     try:
         result = {}
         retid = False
+        special_treatment_sites = ['https://what.cd/', 'http://what.cd/']
 
-        if link.startswith('magnet:'):
+        if link.lower().startswith('magnet:'):
             logger.debug('Deluge: Got a magnet link: %s' % _scrubber(link))
             result = {'type': 'magnet',
                         'url': link}
             retid = _add_torrent_magnet(result)
 
-        elif link.startswith('http://') or link.startswith('https://'):
+        elif link.lower().startswith('http://') or link.lower().startswith('https://'):
             logger.debug('Deluge: Got a URL: %s' % _scrubber(link))
-            user_agent = 'Mozilla/5.0 (Windows NT 6.3; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2243.2 Safari/537.36'
+            if link.lower().startswith(tuple(special_treatment_sites)):
+                user_agent = 'Headphones'
+            else:
+                user_agent = 'Mozilla/5.0 (Windows NT 6.3; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2243.2 Safari/537.36'
             headers = {'User-Agent': user_agent}
             torrentfile = ''
             logger.debug('Deluge: Trying to download (GET)')
@@ -118,7 +122,7 @@ def addTorrent(link, data=None):
             retid = _add_torrent_file(result)
 
         # elif link.endswith('.torrent') or data:
-        elif not (link.startswith('http://') or link.startswith('https://')):
+        elif not (link.lower().startswith('http://') or link.lower().startswith('https://')):
             if data:
                 logger.debug('Deluge: Getting .torrent data')
                 torrentfile = data

--- a/headphones/deluge.py
+++ b/headphones/deluge.py
@@ -58,7 +58,8 @@ def _scrubber(text):
             # URL parameter values
             text = re.sub('=[0-9a-zA-Z]*', '=REMOVED', text)
             # Local host with port
-            text = re.sub('\:\/\/.*\:', '://REMOVED:', text)
+            # text = re.sub('\:\/\/.*\:', '://REMOVED:', text) # just host
+            text = re.sub('\:\/\/.*\:[0-9]*', '://REMOVED:', text)
             # Session cookie
             text = re.sub("_session_id'\: '.*'", "_session_id': 'REMOVED'", text)
             # Local Windows user path
@@ -197,7 +198,7 @@ def getTorrentFolder(result):
                                     result['hash'],
                                     ["total_done"]
                                 ],
-                                "id": 22})
+                                "id": 21})
         response = requests.post(delugeweb_url, data=post_data.encode('utf-8'), cookies=delugeweb_auth,
             verify=deluge_verify_cert)
         result['total_done'] = json.loads(response.text)['result']['total_done']

--- a/headphones/deluge.py
+++ b/headphones/deluge.py
@@ -51,13 +51,14 @@ delugeweb_url = ''
 deluge_verify_cert = False
 scrub_logs = True
 
+
 def _scrubber(text):
     if scrub_logs:
         try:
             # URL parameter values
             text = re.sub('=[0-9a-zA-Z]*', '=REMOVED', text)
             # Local host with port
-            text = re.sub('\:\/\/.*\:' , '://REMOVED:' , text)
+            text = re.sub('\:\/\/.*\:', '://REMOVED:', text)
             # Session cookie
             text = re.sub("_session_id'\: '.*'", "_session_id': 'REMOVED'", text)
             # Local Windows user path
@@ -69,6 +70,7 @@ def _scrubber(text):
         except Exception as e:
             logger.debug('Deluge: Scrubber failed: %s' % str(e))
     return text
+
 
 def addTorrent(link, data=None):
     try:
@@ -287,12 +289,12 @@ def _get_auth():
                             "params": [delugeweb_password],
                             "id": 1})
     try:
-        response = requests.post(delugeweb_url, data=post_data.encode('utf-8'), cookies=delugeweb_auth, 
+        response = requests.post(delugeweb_url, data=post_data.encode('utf-8'), cookies=delugeweb_auth,
             verify=deluge_verify_cert)
     except requests.ConnectionError:
         try:
             logger.debug('Deluge: Connection failed, let\'s try HTTPS just in case')
-            response = requests.post(delugeweb_url.replace('http:', 'https:'), data=post_data.encode('utf-8'), cookies=delugeweb_auth, 
+            response = requests.post(delugeweb_url.replace('http:', 'https:'), data=post_data.encode('utf-8'), cookies=delugeweb_auth,
                 verify=deluge_verify_cert)
             # If the previous line didn't fail, change delugeweb_url for the rest of this session
             logger.error('Deluge: Switching to HTTPS, but certificate won\'t be verified because NO CERTIFICATE WAS CONFIGURED!')
@@ -317,7 +319,7 @@ def _get_auth():
                             "params": [],
                             "id": 10})
     try:
-        response = requests.post(delugeweb_url, data=post_data.encode('utf-8'), cookies=delugeweb_auth, 
+        response = requests.post(delugeweb_url, data=post_data.encode('utf-8'), cookies=delugeweb_auth,
             verify=deluge_verify_cert)
     except Exception as e:
         logger.error('Deluge: Authentication failed: %s' % str(e))
@@ -334,7 +336,7 @@ def _get_auth():
                                 "params": [],
                                 "id": 11})
         try:
-            response = requests.post(delugeweb_url, data=post_data.encode('utf-8'), cookies=delugeweb_auth, 
+            response = requests.post(delugeweb_url, data=post_data.encode('utf-8'), cookies=delugeweb_auth,
                 verify=deluge_verify_cert)
         except Exception as e:
             logger.error('Deluge: Authentication failed: %s' % str(e))
@@ -352,7 +354,7 @@ def _get_auth():
                                 "id": 11})
 
         try:
-            response = requests.post(delugeweb_url, data=post_data.encode('utf-8'), cookies=delugeweb_auth, 
+            response = requests.post(delugeweb_url, data=post_data.encode('utf-8'), cookies=delugeweb_auth,
                 verify=deluge_verify_cert)
         except Exception as e:
             logger.error('Deluge: Authentication failed: %s' % str(e))
@@ -365,7 +367,7 @@ def _get_auth():
                                 "id": 10})
 
         try:
-            response = requests.post(delugeweb_url, data=post_data.encode('utf-8'), cookies=delugeweb_auth, 
+            response = requests.post(delugeweb_url, data=post_data.encode('utf-8'), cookies=delugeweb_auth,
                 verify=deluge_verify_cert)
         except Exception as e:
             logger.error('Deluge: Authentication failed: %s' % str(e))

--- a/headphones/deluge.py
+++ b/headphones/deluge.py
@@ -78,7 +78,7 @@ def addTorrent(link, data=None):
 
         result = {}
         retid = False
-        special_treatment_sites = ['https://what.cd/', 'http://what.cd/']
+        special_treatment_sites = ['https://what.cd/', 'http://what.cd/', 'https://waffles.fm/', 'http://waffles.fm/']
 
         if link.lower().startswith('magnet:'):
             logger.debug('Deluge: Got a magnet link: %s' % _scrubber(link))

--- a/headphones/deluge.py
+++ b/headphones/deluge.py
@@ -390,8 +390,9 @@ def _add_torrent_file(result):
     except UnicodeDecodeError:
         try:
             # content is torrent file contents that needs to be encoded to base64
+            # this time let's try leaving the encoding alone
             post_data = json.dumps({"method": "core.add_torrent_file",
-                                    "params": [result['name'] + '.torrent', b64encode(result['content'].decode('utf-8').encode('utf8')), {}],
+                                    "params": [result['name'] + '.torrent', b64encode(result['content']), {}],
                                     "id": 2})
             response = requests.post(delugeweb_url, data=post_data.encode('utf-8'), cookies=delugeweb_auth,
                 verify=deluge_verify_cert)

--- a/headphones/deluge.py
+++ b/headphones/deluge.py
@@ -268,7 +268,7 @@ def _get_auth():
     try:
         response = requests.post(delugeweb_url, data=post_data.encode('utf-8'), cookies=delugeweb_auth, 
             verify=deluge_verify_cert)
-    except ConnectionError:
+    except requests.ConnectionError:
         try:
             logger.debug('Deluge: Connection failed, let\'s try HTTPS just in case')
             response = requests.post(delugeweb_url.replace('http:', 'https:'), data=post_data.encode('utf-8'), cookies=delugeweb_auth, 

--- a/headphones/deluge.py
+++ b/headphones/deluge.py
@@ -85,6 +85,7 @@ def addTorrent(link, data=None):
         elif link.lower().startswith('http://') or link.lower().startswith('https://'):
             logger.debug('Deluge: Got a URL: %s' % _scrubber(link))
             if link.lower().startswith(tuple(special_treatment_sites)):
+                logger.debug('Deluge: Trying different user-agent for this site')
                 user_agent = 'Headphones'
             else:
                 user_agent = 'Mozilla/5.0 (Windows NT 6.3; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2243.2 Safari/537.36'

--- a/headphones/deluge.py
+++ b/headphones/deluge.py
@@ -237,7 +237,7 @@ def _get_auth():
 
     if delugeweb_cert is None or delugeweb_cert.strip() == '':
         deluge_verify_cert = False
-        logger.debug('Deluge: No SSL certificate configured')
+        logger.debug('Deluge: FYI no SSL certificate configured')
     else:
         deluge_verify_cert = delugeweb_cert
         delugeweb_host = delugeweb_host.replace('http:', 'https:')

--- a/headphones/deluge.py
+++ b/headphones/deluge.py
@@ -72,6 +72,10 @@ def _scrubber(text):
 
 def addTorrent(link, data=None):
     try:
+        # Authenticate anyway
+        logger.debug('Deluge: addTorrent Authentication')
+        _get_auth()
+
         result = {}
         retid = False
         special_treatment_sites = ['https://what.cd/', 'http://what.cd/']

--- a/headphones/deluge.py
+++ b/headphones/deluge.py
@@ -89,8 +89,13 @@ def addTorrent(link, data=None):
         elif link.lower().startswith('http://') or link.lower().startswith('https://'):
             logger.debug('Deluge: Got a URL: %s' % _scrubber(link))
             if link.lower().startswith(tuple(special_treatment_sites)):
-                logger.debug('Deluge: Trying different user-agent for this site')
-                user_agent = 'Headphones'
+                #logger.debug('Deluge: Trying different user-agent for this site')
+                #user_agent = 'Headphones'
+                # This method will make Deluge download the file
+                logger.debug('Deluge: Letting Deluge download this')
+                local_torrent_path = _add_torrent_url({'url': link})
+                logger.debug('Deluge: Returned this local path: %s' % _scrubber(local_torrent_path))
+                return addTorrent(local_torrent_path)
             else:
                 user_agent = 'Mozilla/5.0 (Windows NT 6.3; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2243.2 Safari/537.36'
             headers = {'User-Agent': user_agent}
@@ -391,7 +396,7 @@ def _add_torrent_magnet(result):
         logger.error('; '.join(formatted_lines))
         return False
 
-'''
+
 def _add_torrent_url(result):
     logger.debug('Deluge: Adding URL')
     if not any(delugeweb_auth):
@@ -399,15 +404,17 @@ def _add_torrent_url(result):
     try:
         post_data = json.dumps({"method": "web.download_torrent_from_url",
                                 "params": [result['url'], {}],
-                                "id": 2})
+                                "id": 32})
         response = requests.post(delugeweb_url, data=post_data.encode('utf-8'), cookies=delugeweb_auth,
             verify=deluge_verify_cert)
-        result['hash'] = json.loads(response.text)['result']
+        result['location'] = json.loads(response.text)['result']
         logger.debug('Deluge: Response was %s' % str(json.loads(response.text)))
         return json.loads(response.text)['result']
     except Exception as e:
         logger.error('Deluge: Adding torrent URL failed: %s' % str(e))
-'''
+        formatted_lines = traceback.format_exc().splitlines()
+        logger.error('; '.join(formatted_lines))
+        return False
 
 
 def _add_torrent_file(result):
@@ -430,7 +437,7 @@ def _add_torrent_file(result):
             # this time let's try leaving the encoding as is
             post_data = json.dumps({"method": "core.add_torrent_file",
                                     "params": [result['name'] + '.torrent', b64encode(result['content']), {}],
-                                    "id": 2})
+                                    "id": 22})
             response = requests.post(delugeweb_url, data=post_data.encode('utf-8'), cookies=delugeweb_auth,
                 verify=deluge_verify_cert)
             result['hash'] = json.loads(response.text)['result']

--- a/headphones/postprocessor.py
+++ b/headphones/postprocessor.py
@@ -46,7 +46,7 @@ def checkFolder():
                 if album['Kind'] == 'nzb':
                     download_dir = headphones.CONFIG.DOWNLOAD_DIR
                 else:
-                    if headphones.CONFIG.DELUGE_DONE_DIRECTORY:
+                    if headphones.CONFIG.DELUGE_DONE_DIRECTORY and headphones.CONFIG.TORRENT_DOWNLOADER == 3:
                         download_dir = headphones.CONFIG.DELUGE_DONE_DIRECTORY
                     else:
                         download_dir = headphones.CONFIG.DOWNLOAD_TORRENT_DIR

--- a/headphones/searcher.py
+++ b/headphones/searcher.py
@@ -895,9 +895,9 @@ def send_to_downloader(data, bestqual, album):
             try:
                 # Add torrent
                 if bestqual[3] == 'rutracker.org':
-                    torrentid = deluge.addTorrent('', data)
+                    torrentid = deluge.addTorrent('', data, name=folder_name)
                 else:
-                    torrentid = deluge.addTorrent(bestqual[2])
+                    torrentid = deluge.addTorrent(bestqual[2], name=folder_name)
 
                 if not torrentid:
                     logger.error("Error sending torrent to Deluge. Are you sure it's running? Maybe the torrent already exists?")

--- a/headphones/searcher.py
+++ b/headphones/searcher.py
@@ -917,7 +917,7 @@ def send_to_downloader(data, bestqual, album):
                     deluge.setSeedRatio({'hash': torrentid, 'ratio': seed_ratio})
 
                 # Set move-to directory
-                if headphones.CONFIG.DELUGE_DONE_DIRECTORY:
+                if headphones.CONFIG.DELUGE_DONE_DIRECTORY or headphones.CONFIG.DOWNLOAD_TORRENT_DIR:
                     deluge.setTorrentPath({'hash': torrentid})
 
                 # Get folder name from Deluge, it's usually the torrent name

--- a/headphones/searcher.py
+++ b/headphones/searcher.py
@@ -895,9 +895,9 @@ def send_to_downloader(data, bestqual, album):
             try:
                 # Add torrent
                 if bestqual[3] == 'rutracker.org':
-                    torrentid = deluge.addTorrent('', data, name=folder_name)
+                    torrentid = deluge.addTorrent('', data)
                 else:
-                    torrentid = deluge.addTorrent(bestqual[2], name=folder_name)
+                    torrentid = deluge.addTorrent(bestqual[2])
 
                 if not torrentid:
                     logger.error("Error sending torrent to Deluge. Are you sure it's running? Maybe the torrent already exists?")
@@ -920,14 +920,13 @@ def send_to_downloader(data, bestqual, album):
                 if headphones.CONFIG.DELUGE_DONE_DIRECTORY:
                     deluge.setTorrentPath({'hash': torrentid})
 
-                # I only just realized this function is useless...
-                # Hadn't realized folder_name was already being set to Artist - Album
-                #folder_name = deluge.getTorrentFolder({'hash': torrentid})
-                #if folder_name:
-                #    logger.info('Torrent folder name: %s' % folder_name)
-                #else:
-                #    logger.error('Torrent folder name could not be determined')
-                #    return
+                # Get folder name from Deluge, it's usually the torrent name
+                folder_name = deluge.getTorrentFolder({'hash': torrentid})
+                if folder_name:
+                    logger.info('Torrent folder name: %s' % folder_name)
+                else:
+                    logger.error('Torrent folder name could not be determined')
+                    return
 
             except Exception as e:
                 logger.error('Error sending torrent to Deluge: %s' % str(e))

--- a/headphones/searcher.py
+++ b/headphones/searcher.py
@@ -921,12 +921,13 @@ def send_to_downloader(data, bestqual, album):
                     deluge.setTorrentPath({'hash': torrentid})
 
                 # I only just realized this function is useless...
-                folder_name = deluge.getTorrentFolder({'hash': torrentid})
-                if folder_name:
-                    logger.info('Torrent folder name: %s' % folder_name)
-                else:
-                    logger.error('Torrent folder name could not be determined')
-                    return
+                # Hadn't realized folder_name was already being set to Artist - Album
+                #folder_name = deluge.getTorrentFolder({'hash': torrentid})
+                #if folder_name:
+                #    logger.info('Torrent folder name: %s' % folder_name)
+                #else:
+                #    logger.error('Torrent folder name could not be determined')
+                #    return
 
             except Exception as e:
                 logger.error('Error sending torrent to Deluge: %s' % str(e))

--- a/headphones/webserve.py
+++ b/headphones/webserve.py
@@ -1157,6 +1157,7 @@ class WebInterface(object):
             "transmission_username": headphones.CONFIG.TRANSMISSION_USERNAME,
             "transmission_password": headphones.CONFIG.TRANSMISSION_PASSWORD,
             "deluge_host": headphones.CONFIG.DELUGE_HOST,
+            "deluge_cert": headphones.CONFIG.DELUGE_CERT,
             "deluge_password": headphones.CONFIG.DELUGE_PASSWORD,
             "deluge_label": headphones.CONFIG.DELUGE_LABEL,
             "deluge_done_directory": headphones.CONFIG.DELUGE_DONE_DIRECTORY,


### PR DESCRIPTION
- Fix #2546 - Always authenticate to avoid expired cookies
- Fix #2540 - Better DL - fix for specific sites, also use HTTPS (without verification for self-signed certificates unfortunately)
- Log scrubbing for some sensitive info