### PR TITLE
pep: fix e261

### DIFF
--- a/.pep8
+++ b/.pep8
@@ -6,10 +6,9 @@
 # E126 continuation line over-indented for hanging indent
 # E127 continuation line over-indented for visual indent
 # E128 continuation line under-indented for visual indent
-# E261 at least two spaces before inline comment
 # E262 inline comment should start with '# '
 # E265 block comment should start with '# '
 # E501 line too long (312 > 160 characters)
 # E502 the backslash is redundant between brackets
-ignore = E121,E122,E123,E124,E125,E126,E127,E128,E261,E262,E265,E501,E502
+ignore = E121,E122,E123,E124,E125,E126,E127,E128,E262,E265,E501,E502
 max-line-length = 160

--- a/headphones/postprocessor.py
+++ b/headphones/postprocessor.py
@@ -457,7 +457,7 @@ def doPostProcessing(albumid, albumpath, release, tracks, downloaded_track_list,
             release['ArtistName'], release['AlbumTitle']))
             if headphones.CONFIG.TORRENT_DOWNLOADER == 1:
                 torrent_removed = transmission.removeTorrent(hash, True)
-            elif headphones.CONFIG.TORRENT_DOWNLOADER == 3: # Deluge
+            elif headphones.CONFIG.TORRENT_DOWNLOADER == 3:  # Deluge
                 torrent_removed = deluge.removeTorrent(hash, True)
             else:
                 torrent_removed = utorrent.removeTorrent(hash, True)

--- a/headphones/searcher.py
+++ b/headphones/searcher.py
@@ -889,7 +889,7 @@ def send_to_downloader(data, bestqual, album):
             if seed_ratio is not None:
                 transmission.setSeedRatio(torrentid, seed_ratio)
 
-        elif headphones.CONFIG.TORRENT_DOWNLOADER == 3: # Deluge
+        elif headphones.CONFIG.TORRENT_DOWNLOADER == 3:  # Deluge
             logger.info("Sending torrent to Deluge")
 
             try:


### PR DESCRIPTION
Fix `E261 at least two spaces before inline comment` in the code.