### PR TITLE
Custom build badges in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ##![Headphones Logo](https://github.com/rembo10/headphones/raw/master/data/images/headphoneslogo.png) Headphones
 
-**Master Branch:**  [![Build Status](https://travis-ci.org/rembo10/headphones.svg?branch=master)](https://travis-ci.org/rembo10/headphones)
-**Develop Branch:** [![Build Status](https://travis-ci.org/rembo10/headphones.svg?branch=develop)](https://travis-ci.org/rembo10/headphones)
+[![Build Status](https://travis-ci.org/rembo10/headphones.svg?branch=master)](https://travis-ci.org/rembo10/headphones)
+[![Build Status](https://img.shields.io/travis/rembo10/headphones/develop.svg?label=develop%20branch%20build)](https://travis-ci.org/rembo10/headphones)
 
 Headphones is an automated music downloader for NZB and Torrent, written in Python. It supports SABnzbd, NZBget, Transmission, µTorrent, Deluge and Blackhole.
 


### PR DESCRIPTION
Their lack of alignment irked me a bit :sweat_smile: 

Old:
<img width="444" alt="" src="https://cloud.githubusercontent.com/assets/1402241/13624957/a6f6f36c-e567-11e5-8c09-6b5b8449b7c3.png">

New:

<img width="300" alt="" src="https://cloud.githubusercontent.com/assets/1402241/13624956/a6f37f48-e567-11e5-8ac4-bbbe7d2bc934.png">

What do you think?