### PR TITLE
Fix broken build (headphones.exceptions for softchroot)

### DIFF
--- a/headphones/__init__.py
+++ b/headphones/__init__.py
@@ -143,7 +143,7 @@ def initialize(config_file):
             SOFT_CHROOT = SoftChroot(str(CONFIG.SOFT_CHROOT))
             if SOFT_CHROOT.isEnabled():
                 logger.info("Soft-chroot enabled for dir: %s", str(CONFIG.SOFT_CHROOT))
-        except exceptions.SoftChrootError as e:
+        except headphones.exceptions.SoftChrootError as e:
             logger.error("SoftChroot error: %s", e)
             raise e
 


### PR DESCRIPTION
FIX: bug with fullname of `headphones.exceptions`, visible just for pyflakes