### PR TITLE
Handle iTunes non-existant 'Various Artists' vs compilation tag (fixes #2296)

### DIFF
--- a/headphones/librarysync.py
+++ b/headphones/librarysync.py
@@ -126,9 +126,11 @@ def libraryScan(dir=None, append=False, ArtistID=None, ArtistName=None,
                 if f.bitrate:
                     bitrates.append(f.bitrate)
 
-                # Use the album artist over the artist if available
+                # Use the album artist over the artist if available. Hard set 'Various Artists' if no albumartist but compilation tag set (iTunes)
                 if f.albumartist:
                     f_artist = f.albumartist
+                elif f.comp:
+                    f_artist = 'Various Artists'
                 elif f.artist:
                     f_artist = f.artist
                 else:


### PR DESCRIPTION
In a healthy iTunes library, 'Various Artists' compilations have the compilation tag set to 1, and albumartist is empty.
So if there is no albumartist, but compilation tag is set, assume 'Various Artists'.