### PR TITLE
Change the umask for headphones to 007 

### DIFF
--- a/headphones/__init__.py
+++ b/headphones/__init__.py
@@ -225,7 +225,7 @@ def daemonize():
 
     # Make sure I can read my own files and shut out others
     prev = os.umask(0)  # @UndefinedVariable - only available in UNIX
-    os.umask(prev and int('077', 8))
+    os.umask(prev and int('007', 8))
 
     # Make the child a session-leader by detaching from the terminal
     try:


### PR DESCRIPTION
This allows other users in the same group as headphones to read/modify/delete/move files created by headphones.

This is particularly useful if, say, you don't run your NZB downloader under the same account, or if you (like me) have an NFS share and want to clean up the output folder after importing downloaded files.