### PR TITLE
Fix infinite .orig.nfo extension suffix addition

### DIFF
--- a/headphones/postprocessor.py
+++ b/headphones/postprocessor.py
@@ -662,15 +662,16 @@ def renameNFO(albumpath):
     for r, d, f in os.walk(albumpath):
         for file in f:
             if file.lower().endswith('.nfo'):
-                logger.debug('Renaming: "%s" to "%s"' % (
-                file.decode(headphones.SYS_ENCODING, 'replace'),
-                file.decode(headphones.SYS_ENCODING, 'replace') + '-orig'))
-                try:
-                    new_file_name = os.path.join(r, file)[:-3] + 'orig.nfo'
-                    os.rename(os.path.join(r, file), new_file_name)
-                except Exception as e:
-                    logger.error(u'Could not rename file: %s. Error: %s' % (
-                    os.path.join(r, file).decode(headphones.SYS_ENCODING, 'replace'), e))
+                if not file.lower().endswith('.orig.nfo'):
+                    logger.debug('Renaming: "%s" to "%s"' % (
+                    file.decode(headphones.SYS_ENCODING, 'replace'),
+                    file.decode(headphones.SYS_ENCODING, 'replace') + '-orig'))
+                    try:
+                        new_file_name = os.path.join(r, file)[:-3] + 'orig.nfo'
+                        os.rename(os.path.join(r, file), new_file_name)
+                    except Exception as e:
+                        logger.error(u'Could not rename file: %s. Error: %s' % (
+                        os.path.join(r, file).decode(headphones.SYS_ENCODING, 'replace'), e))
 
 
 def moveFiles(albumpath, release, tracks):


### PR DESCRIPTION
Fix the infinite addition of .orig. into the file suffix where filenames would tentatively become FILENAME.orig.orig.orig.orig.orig.orig.orig.orig.nfo etc, before causing an exception in processing.