### PR TITLE
Fixed FreeBSD init script.

### DIFF
--- a/init-scripts/init.freebsd
+++ b/init-scripts/init.freebsd
@@ -1,7 +1,8 @@
 #!/bin/sh
 #
 # PROVIDE: headphones
-# REQUIRE: DAEMON sabnzbd
+# REQUIRE: DAEMON
+# BEFORE:  LOGIN
 # KEYWORD: shutdown
 #
 # Add the following lines to /etc/rc.conf.local or /etc/rc.conf
@@ -15,56 +16,34 @@
 #           as root.
 # headphones_dir:   Directory where Headphones lives.
 #           Default: /usr/local/headphones
-# headphones_chdir:  Change to this directory before running Headphones.
-#     Default is same as headphones_dir.
 # headphones_pid:  The name of the pidfile to create.
 #     Default is headphones.pid in headphones_dir.
-PATH="/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin"
 
 . /etc/rc.subr
 
 name="headphones"
 rcvar=${name}_enable
 
-load_rc_config ${name}
-
 : "${headphones_enable:="NO"}"
 : "${headphones_user:="_sabnzbd"}"
 : "${headphones_dir:="/usr/local/headphones"}"
-: "${headphones_chdir:="${headphones_dir}"}"
-: "${headphones_pid:="${headphones_dir}/headphones.pid"}"
+: "${headphones_conf:="/usr/local/headphones/config.ini"}"
 
-status_cmd="${name}_status"
-stop_cmd="${name}_stop"
+command="${headphones_dir}/Headphones.py"
+command_interpreter="/usr/bin/python"
+pidfile="/var/run/headphones/headphones.pid"
+start_precmd="headphones_start_precmd"
+headphones_flags="--daemon --nolaunch --pidfile $pidfile --config $headphones_conf $headphones_flags"
 
-command="/usr/sbin/daemon"
-command_args="-f -p ${headphones_pid} python ${headphones_dir}/Headphones.py ${headphones_flags} --quiet --nolaunch"
+headphones_start_precmd() {
+        if [ $($ID -u) != 0 ]; then
+                err 1 "Must be root."
+        fi
 
-# Ensure user is root when running this script.
-if [ "$(id -u)" != "0" ]; then
-  echo "Oops, you should be root before running this!"
-  exit 1
-fi
-
-verify_headphones_pid() {
-    # Make sure the pid corresponds to the Headphones process.
-    pid=$(cat "${headphones_pid}" 2>/dev/null)
-    pgrep -F "${headphones_pid}" -q "python ${headphones_dir}/Headphones.py"
-    return $?
+	if [ ! -d /var/run/headphones ]; then
+		install -do $headphones_user /var/run/headphones
+	fi
 }
 
-# Try to stop Headphones cleanly by calling shutdown over http.
-headphones_stop() {
-    echo "Stopping $name"
-    verify_headphones_pid
-    if [ -n "${pid}" ]; then
-      wait_for_pids "${pid}"
-      echo "Stopped"
-    fi
-}
-
-headphones_status() {
-    verify_headphones_pid && echo "$name is running as ${pid}" || echo "$name is not running"
-}
-
+load_rc_config ${name}
 run_rc_command "$1"


### PR DESCRIPTION
Several things were done wrong or badly. See [Practical rc.d scripting in BSD](https://www.freebsd.org/doc/en/articles/rc-scripting/article.html), [`rc`](https://www.freebsd.org/cgi/man.cgi?query=rc&sektion=8&manpath=freebsd-release-ports), [`rcorder`](https://www.freebsd.org/cgi/man.cgi?query=rcorder&sektion=8&manpath=freebsd-release-ports) and [`rc.subr`](https://www.freebsd.org/cgi/man.cgi?query=rc.subr&apropos=0&sektion=8&manpath=FreeBSD+10.3-RELEASE+and+Ports&arch=default&format=html).

- `/usr/sbin/daemon` is not really necessary. `command` and `command_interpreter` work perfectly fine
- `command_args` was used incorrectly. I replaced it with `headphones_flags`.
- I don't like to `REQUIRE` sabnzbd as other downloaders are compatible. It does meet the guidelines as it does work "better" if sab starts first. Perhaps adding all the compatible downloaders would be appropriate. It's probably fine without any of them though.
- The script should also probably be `BEFORE` login.
- `--daemon` was not used and `--quiet` was unneccesary (and could hide valuable error information).
- I don't know why the stop command was overridden. If headphones doesn't quit gracefully on `SIGTERM` then it should otherwise it's not much of a daemon.
- `pidfile` should be set. I also added some logic to create a folder in `/var/run` with adequate permissions if it doesn't exist.
- Took out `headphones_chdir` and `PATH` as they are not really needed AFAIK.
- Moved `load_rc_config ${name}`. It wasn't wrong where it was I just like it better where it is.