### PR TITLE
Fix Rutracker loggin by looking for the cookie in request history

### DIFF
--- a/headphones/rutracker.py
+++ b/headphones/rutracker.py
@@ -46,10 +46,10 @@ class Rutracker(object):
         try:
             r = self.session.post(loginpage, data=post_params, timeout=self.timeout, allow_redirects=False)
             # try again
-            if 'bb_data' not in r.cookies.keys():
+            if not self.has_bb_data_cookie(r):
                 time.sleep(10)
                 r = self.session.post(loginpage, data=post_params, timeout=self.timeout, allow_redirects=False)
-            if 'bb_data' in r.cookies.keys():
+            if self.has_bb_data_cookie(r):
                 self.loggedin = True
                 logger.info("Successfully logged in to rutracker")
             else:
@@ -61,6 +61,12 @@ class Rutracker(object):
             logger.error("Unknown error logging in to rutracker: %s" % e)
             self.loggedin = False
             return self.loggedin
+
+    def has_bb_data_cookie(self, response):
+        if 'bb_data' in response.cookies.keys():
+            return True
+        # Rutracker randomly send a 302 redirect code, cookie may be present in response history
+        return next(('bb_data' in r.cookies.keys() for r in response.history), False)
 
     def searchurl(self, artist, album, year, format):
         """


### PR DESCRIPTION
rutracker.org randomly makes a redirection upon login (HTTP 302). That was fooling the current system that couldn't find the cookie in request's response  - in my case, 80% of the time. This is probably the cause for issue #2595.

```
In [5]: r = requests.post(loginpage, data=post_params)

In [6]: r.cookies.keys()
Out[6]: []
```

However by just checking for cookie's presence in request history we're able to fix the existing login :

```
In [17]: r.history
Out[17]: (<Response [302]>,)

In [18]: r.history[0].cookies.keys()
Out[18]: ['bb_data']
```

