### PR TITLE
Update T411 new domain ( t411.li )

### DIFF
--- a/headphones/searcher.py
+++ b/headphones/searcher.py
@@ -1801,7 +1801,7 @@ def searchTorrent(album, new=False, losslessOnly=False, albumlength=None,
     if headphones.CONFIG.TQUATTRECENTONZE:
         username = headphones.CONFIG.TQUATTRECENTONZE_USER
         password = headphones.CONFIG.TQUATTRECENTONZE_PASSWORD
-        API_URL = "http://api.t411.ch"
+        API_URL = "http://api.t411.li"
         AUTH_URL = API_URL + '/auth'
         DL_URL = API_URL + '/torrents/download/'
         provider = "t411"


### PR DESCRIPTION
Although the API from the old domain is still working, I am anticipating its future shutdown. 
The API on the new domain is now functionnal.