### PR TITLE
Date Added Column for Home Page

### DIFF
--- a/data/interfaces/default/css/style.css
+++ b/data/interfaces/default/css/style.css
@@ -1015,6 +1015,11 @@ div#artistheader h2 a {
   text-align: left;
   vertical-align: middle;
 }
+#artist_table td#added {
+  min-width: 100px;
+  text-align: left;
+  vertical-align: middle;
+}
 #markalbum {
   position: relative;
   top: 25px;

--- a/data/interfaces/default/index.html
+++ b/data/interfaces/default/index.html
@@ -12,6 +12,7 @@
 				<th id="status">Status</th>
 				<th id="album">Latest Release</th>
 				<th id="have">Have</th>
+				<th id="added">Added</th>
 			</tr>
 		</thead>
 		<tbody>
@@ -101,6 +102,9 @@
                             return '<span title="' + percent + '"></span><div class="progress-container"><div style="width:' + percent + '%"><div class="havetracks">' + full['HaveTracks'] + '/' + full['TotalTracks'] + '</div></div></div>';
                         }
                     },
+                    {
+                        "aTargets":[5],"mDataProp":"DateAdded"
+                    },
                 ],
     			"oLanguage": {
     				"sSearch": "",
@@ -123,6 +127,7 @@
                     nRow.children[2].id = 'status'
                     nRow.children[3].id = 'album'
                     nRow.children[4].id = 'have'
+                    nRow.children[5].id = 'added'
                     return nRow;
                 },
                 "fnServerData": function ( sSource, aoData, fnCallback ) {

--- a/headphones/webserve.py
+++ b/headphones/webserve.py
@@ -998,6 +998,8 @@ class WebInterface(object):
             sortcolumn = 'ReleaseDate'
         elif iSortCol_0 == '4':
             sortbyhavepercent = True
+        elif iSortCol_0 == '5':
+            sortcolumn = 'DateAdded'
 
         if sSearch == "":
             query = 'SELECT * from artists order by %s COLLATE NOCASE %s' % (sortcolumn, sSortDir_0)
@@ -1032,6 +1034,7 @@ class WebInterface(object):
                    "ReleaseDate": "",
                    "ReleaseInFuture": "False",
                    "AlbumID": "",
+                   "DateAdded": artist["DateAdded"],
                    }
 
             if not row['HaveTracks']:


### PR DESCRIPTION
For #2881 

Not sure how useful the date added column would be for others but apparently there are at couple of us that would like the column.  I called the column "Added" for brevity but maybe it should "Date Added" instead?

The "Last Updated" column is already available on the manage artists page, so maybe this extra column isn't useful enough to clutter the main page, or maybe this should be added as an additional column to the manage artists page instead?