### PR TITLE
rutracker optional session cookie

### DIFF
--- a/data/interfaces/default/config.html
+++ b/data/interfaces/default/config.html
@@ -649,6 +649,10 @@
                                             <label>Seed Ratio</label>
                                             <input type="text" class="override-float" name="rutracker_ratio" value="${config['rutracker_ratio']}" size="10" title="Stop seeding when ratio met, 0 = unlimited. Scheduled job will remove torrent when post processed and finished seeding">
                                         </div>
+                                        <div class="row">
+                                            <label>Session Cookie (Optional - Advanced)</label>
+                                            <input type="text" class="override-float" name="rutracker_cookie" value="${config['rutracker_cookie']}" size="10" title="bb_session cookie (Advanced)">
+                                        </div>
                                     </div>
                                 </fieldset>
 

--- a/headphones/config.py
+++ b/headphones/config.py
@@ -248,6 +248,7 @@ _CONFIG_DEFINITIONS = {
     'RUTRACKER_PASSWORD': (str, 'Rutracker', ''),
     'RUTRACKER_RATIO': (str, 'Rutracker', ''),
     'RUTRACKER_USER': (str, 'Rutracker', ''),
+    'RUTRACKER_COOKIE': (str, 'Rutracker', ''),
     'SAB_APIKEY': (str, 'SABnzbd', ''),
     'SAB_CATEGORY': (str, 'SABnzbd', ''),
     'SAB_HOST': (str, 'SABnzbd', ''),

--- a/headphones/rutracker.py
+++ b/headphones/rutracker.py
@@ -51,7 +51,7 @@ class Rutracker(object):
                 time.sleep(10)
                 if headphones.CONFIG.RUTRACKER_COOKIE:
                     logger.info("Attempting to log in using predefined cookie...")
-                    r = self.session.post(loginpage, data=post_params, timeout=self.timeout, allow_redirects=False, cookies={'bb_session':headphones.CONFIG.RUTRACKER_COOKIE})
+                    r = self.session.post(loginpage, data=post_params, timeout=self.timeout, allow_redirects=False, cookies={'bb_session': headphones.CONFIG.RUTRACKER_COOKIE})
                 else:
                     r = self.session.post(loginpage, data=post_params, timeout=self.timeout, allow_redirects=False)
             if self.has_bb_session_cookie(r):

--- a/headphones/rutracker.py
+++ b/headphones/rutracker.py
@@ -49,7 +49,10 @@ class Rutracker(object):
             # try again
             if not self.has_bb_session_cookie(r):
                 time.sleep(10)
-                r = self.session.post(loginpage, data=post_params, timeout=self.timeout, allow_redirects=False)
+                if headphones.CONFIG.RUTRACKER_COOKIE:
+                    r = self.session.post(loginpage, data=post_params, timeout=self.timeout, allow_redirects=False, cookies={'bb_session':headphones.CONFIG.RUTRACKER_COOKIE})
+                else:
+                    r = self.session.post(loginpage, data=post_params, timeout=self.timeout, allow_redirects=False)
             if self.has_bb_session_cookie(r):
                 self.loggedin = True
                 logger.info("Successfully logged in to rutracker")

--- a/headphones/rutracker.py
+++ b/headphones/rutracker.py
@@ -50,6 +50,7 @@ class Rutracker(object):
             if not self.has_bb_session_cookie(r):
                 time.sleep(10)
                 if headphones.CONFIG.RUTRACKER_COOKIE:
+                    logger.info("Attempting to log in using predefined cookie...")
                     r = self.session.post(loginpage, data=post_params, timeout=self.timeout, allow_redirects=False, cookies={'bb_session':headphones.CONFIG.RUTRACKER_COOKIE})
                 else:
                     r = self.session.post(loginpage, data=post_params, timeout=self.timeout, allow_redirects=False)

--- a/headphones/webserve.py
+++ b/headphones/webserve.py
@@ -1240,6 +1240,7 @@ class WebInterface(object):
             "rutracker_user": headphones.CONFIG.RUTRACKER_USER,
             "rutracker_password": headphones.CONFIG.RUTRACKER_PASSWORD,
             "rutracker_ratio": headphones.CONFIG.RUTRACKER_RATIO,
+            "rutracker_cookie": headphones.CONFIG.RUTRACKER_COOKIE,
             "use_apollo": checked(headphones.CONFIG.APOLLO),
             "apollo_username": headphones.CONFIG.APOLLO_USERNAME,
             "apollo_password": headphones.CONFIG.APOLLO_PASSWORD,


### PR DESCRIPTION
Trouble logging in may be caused due to captcha. Using a pre-existing cookie from an authenticated browser session may serve as a workaround. 