### PR TITLE
Add 3000 as torznab category because it also matches audio

### DIFF
--- a/headphones/searcher.py
+++ b/headphones/searcher.py
@@ -1288,9 +1288,9 @@ def searchTorrent(album, new=False, losslessOnly=False, albumlength=None,
         if headphones.CONFIG.PREFERRED_QUALITY == 3 or losslessOnly:
             categories = "3040"
         elif headphones.CONFIG.PREFERRED_QUALITY == 1 or allow_lossless:
-            categories = "3040,3010,3050"
+            categories = "3040,3010,3050,3000"
         else:
-            categories = "3010,3050"
+            categories = "3010,3050,3000"
 
         if album['Type'] == 'Other':
             categories = "3030"


### PR DESCRIPTION
I'm running Jackett and noticed that 3000 was not being passed through resulting in many misses. I couldn't find any tests to extend to test this change.