### PR TITLE
Sorted wanted albums by release date.

### DIFF
--- a/headphones/webserve.py
+++ b/headphones/webserve.py
@@ -537,7 +537,7 @@ class WebInterface(object):
         myDB = db.DBConnection()
         upcoming = myDB.select(
             "SELECT * from albums WHERE ReleaseDate > date('now') order by ReleaseDate ASC")
-        wanted = myDB.select("SELECT * from albums WHERE Status='Wanted'")
+        wanted = myDB.select("SELECT * from albums WHERE Status='Wanted' order by ReleaseDate ASC")
         return serve_template(templatename="upcoming.html", title="Upcoming", upcoming=upcoming,
                               wanted=wanted)
 


### PR DESCRIPTION
Without this SQLite will order the results by whichever column happens to be the fastest for it. This will usually result in the rows being sorted by the primary key (or rowid).

Sorting by release date also matches the sort order of the "upcoming" albums list.