### PR TITLE
Fix SYS_ENCODING selection on Windows

### DIFF
--- a/Headphones.py
+++ b/Headphones.py
@@ -54,7 +54,10 @@ def main():
 
     try:
         locale.setlocale(locale.LC_ALL, "")
-        headphones.SYS_ENCODING = locale.getpreferredencoding()
+        if headphones.SYS_PLATFORM == 'win32':
+            headphones.SYS_ENCODING = sys.getdefaultencoding().upper()
+        else:
+            headphones.SYS_ENCODING = locale.getpreferredencoding()
     except (locale.Error, IOError):
         pass
 


### PR DESCRIPTION
This fixes broken special characters(like umlauts, showing as ") in the console output. 
Unfortunately does not fix headphones running on Windows not seeing folders with japanese characters etc but at least gets rid of a small annoyance.

locale.getpreferredencoding() on Windows returns 'cp1252' (at least on a 1252 locale), but this encoding isn't actually used for filenames. sys.getdefaultencoding() in my testing returns 'ascii' on Python 2.7(and 'utf-8' on 3.6) so it gets set to UTF-8 in the end.