### PR TITLE
Select highest quality available if no FLAC found

### DIFF
--- a/headphones/searcher.py
+++ b/headphones/searcher.py
@@ -609,7 +609,7 @@ def searchNZB(album, new=False, losslessOnly=False, albumlength=None,
         if headphones.CONFIG.PREFERRED_QUALITY == 3 or losslessOnly:
             categories = "3040"
         elif headphones.CONFIG.PREFERRED_QUALITY == 1 or allow_lossless:
-            categories = "3040,3010"
+            categories = "3000"
         else:
             categories = "3010"
 


### PR DESCRIPTION
This sends an API search for the "Audio" category instead of the "Audio Flac" category. This fixes an issue where an MP3 file would not be selected if available but no Flac file was available.