### PR TITLE
Items from torznab are not returned when size is defined as torznab:attr

### DIFF
--- a/headphones/searcher.py
+++ b/headphones/searcher.py
@@ -1353,8 +1353,10 @@ def searchTorrent(album, new=False, losslessOnly=False, albumlength=None,
                                 else:
                                     logger.info('Skipping %s, could not determine size' % title)
                                     continue
-                            else:
+                            elif item.size:
                                 size = int(item.size.string)
+                            else:
+                                size = int(item.find("torznab:attr", attrs={"name": "size"}).get('value'))
 
                             if all(word.lower() in title.lower() for word in term.split()):
                                 if size < maxsize and minimumseeders < seeders:


### PR DESCRIPTION
When this occurs, the following exception is raised
```
30-Mar-2018 16:21:53 - ERROR :: Thread-17 : An unknown error occurred trying to parse the feed: 'NoneType' object has no attribute 'string'
Traceback (most recent call last):
  File "/opt/headphones/headphones/searcher.py", line 1357, in searchTorrent
    size = int(item.size.string)
AttributeError: 'NoneType' object has no attribute 'string'
```
Replaces #3103 