### PR TITLE
sort Apollo.rip results by number of seeders

### DIFF
--- a/headphones/searcher.py
+++ b/headphones/searcher.py
@@ -431,7 +431,7 @@ def sort_search_results(resultlist, album, new, albumlength):
 
     resultlist = temp_list
 
-    if headphones.CONFIG.PREFERRED_QUALITY == 2 and headphones.CONFIG.PREFERRED_BITRATE:
+    if headphones.CONFIG.PREFERRED_QUALITY == 2 and headphones.CONFIG.PREFERRED_BITRATE and result[3] != 'Apollo.rip':
 
         try:
             targetsize = albumlength / 1000 * int(headphones.CONFIG.PREFERRED_BITRATE) * 128
@@ -459,6 +459,10 @@ def sort_search_results(resultlist, album, new, albumlength):
                         (result[0], result[1], result[2], result[3], result[4], result[5], delta))
 
                 finallist = sorted(newlist, key=lambda title: (-title[5], title[6]))
+
+                # keep number of seeders order for Apollo.rip
+                if result[3] == 'Apollo.rip':
+                    finallist = resultlist
 
                 if not len(finallist) and len(
                         flac_list) and headphones.CONFIG.PREFERRED_BITRATE_ALLOW_LOSSLESS:
@@ -1557,13 +1561,11 @@ def searchTorrent(album, new=False, losslessOnly=False, albumlength=None,
             elif len(match_torrents) > 1:
                 logger.info(u"Found %d matching releases from %s for %s - %s after filtering" %
                             (len(match_torrents), provider, artistterm, albumterm))
-                logger.info(
-                    "Sorting torrents by times snatched and preferred bitrate %s..." % bitrate_string)
-                match_torrents.sort(key=lambda x: int(x.snatched), reverse=True)
+                logger.info('Sorting torrents by number of seeders...')
+                match_torrents.sort(key=lambda x: int(x.seeders), reverse=True)
                 if gazelleformat.MP3 in search_formats:
-                    # sort by size after rounding to nearest 10MB...hacky, but will favor highest quality
-                    match_torrents.sort(key=lambda x: int(10 * round(x.size / 1024. / 1024. / 10.)),
-                                        reverse=True)
+                    logger.info('Sorting torrents by seeders...')
+                    match_torrents.sort(key=lambda x: int(x.seeders), reverse=True)
                 if search_formats and None not in search_formats:
                     match_torrents.sort(
                         key=lambda x: int(search_formats.index(x.format)))  # prefer lossless
@@ -1882,7 +1884,7 @@ def searchTorrent(album, new=False, losslessOnly=False, albumlength=None,
     results = [result for result in resultlist if verifyresult(result[0], artistterm, term, losslessOnly)]
 
     # Additional filtering for size etc
-    if results and not choose_specific_download:
+    if results and not choose_specific_download and result[3] != 'Apollo.rip':
         results = more_filtering(results, album, albumlength, new)
 
     return results


### PR DESCRIPTION
Previous behavior was to arbitrarily pick torrent by size. This commit will instead pick the torrent with the highest amount of seeders. This filtering is preferred as the torrent with the highest amount of seeders is generally the best result - community consensus of which upload is best by popularity, provides the fastest download speed, and gives you the most upload potential. 

Testing results:

id 1159880 = 194 seeders
id 1163752 = 9 seeders
id 1162109 = 6 seeders

```
03-Jul-2018 09:43:04 - INFO    :: CP Server Thread-6 : Marking album: a63e5fa6-d6ad-47bd-986d-4a27b0c9de70 as wanted...
03-Jul-2018 09:43:04 - INFO    :: CP Server Thread-6 : Searching for wanted albums
03-Jul-2018 09:43:04 - INFO    :: CP Server Thread-6 : Searching for "Nine Inch Nails - Bad Witch" since it was marked as wanted
03-Jul-2018 09:43:04 - DEBUG   :: CP Server Thread-6 : Using search term: Nine Inch Nails Bad Witch
03-Jul-2018 09:43:04 - INFO    :: CP Server Thread-6 : Attempting to log in to Apollo.rip...
03-Jul-2018 09:43:06 - INFO    :: CP Server Thread-6 : Searching Apollo.rip...
03-Jul-2018 09:43:06 - INFO    :: CP Server Thread-6 : Filtering torrents by format, maximum size, and minimum seeders...
03-Jul-2018 09:43:06 - INFO    :: CP Server Thread-6 : Remaining torrents: Torrent: Bad Witch - V0 (VBR) - ID: 1163752, Torrent: Bad Witch - V0 (VBR) - ID: 1159880, Torrent: Bad Witch - V0 (VBR) - ID: 1162109
03-Jul-2018 09:43:06 - INFO    :: CP Server Thread-6 : Found 3 matching releases from Apollo.rip for Nine Inch Nails - Bad Witch after filtering
03-Jul-2018 09:43:06 - INFO    :: CP Server Thread-6 : Sorting torrents by number of seeders...
03-Jul-2018 09:43:06 - INFO    :: CP Server Thread-6 : New order: Torrent: Bad Witch - V0 (VBR) - ID: 1159880, Torrent: Bad Witch - V0 (VBR) - ID: 1163752, Torrent: Bad Witch - V0 (VBR) - ID: 1162109
03-Jul-2018 09:43:07 - INFO    :: CP Server Thread-6 : Removed 'Nine Inch Nails   2018   Bad Witch (44 1 16 Vinyl Rip) (V0)' from results because it contains ignored word: 'vinyl'
03-Jul-2018 09:43:07 - INFO    :: CP Server Thread-6 : Making sure we can download the best result
03-Jul-2018 09:43:07 - INFO    :: CP Server Thread-6 : Found best result from Apollo.rip: <a href="https://apollo.rip/torrents.php?action=download&id=1159880&authkey=XXX&torrent_pass=XXX">Nine Inch Nails - Bad Witch (2018) [V0 WEB]</a> - 60.0 MB
03-Jul-2018 09:43:07 - INFO    :: CP Server Thread-6 : Sending torrent to Transmission
03-Jul-2018 09:43:07 - DEBUG   :: CP Server Thread-6 : Requesting URL via GET method: http://localhost:9091/transmission/rpc
03-Jul-2018 09:43:07 - DEBUG   :: CP Server Thread-6 : Retrying Transmission request with new session id
03-Jul-2018 09:43:07 - DEBUG   :: CP Server Thread-6 : Requesting URL via POST method: http://localhost:9091/transmission/rpc
```

result is id 1159880 with the most seeders snatched