### PR TITLE
Update searcher.py

### DIFF
--- a/headphones/searcher.py
+++ b/headphones/searcher.py
@@ -1186,10 +1186,12 @@ def verifyresult(title, artistterm, term, lossless):
 
     return True
 
+
 def replace_all(text, dic):
     for i, j in dic.iteritems():
         text = text.replace(i, j)
     return text
+
 
 def searchTorrent(album, new=False, losslessOnly=False, albumlength=None,
                   choose_specific_download=False):
@@ -1206,13 +1208,13 @@ def searchTorrent(album, new=False, losslessOnly=False, albumlength=None,
 
     semi_cleanalbum = replace_all(album['AlbumTitle'], dic)
     semi_cleanartist = replace_all(album['ArtistName'], dic)
-	
+
     cleanartist = helpers.latinToAscii(semi_cleanartist)
     cleanartist = re.sub('[\.\-\/]', ' ', cleanartist).encode('utf-8', 'replace')
-	
+
     cleanalbum = helpers.latinToAscii(semi_cleanalbum)
     cleanalbum = re.sub('[\.\-\/]', ' ', cleanalbum).encode('utf-8', 'replace')
-		
+	
     logger.debug ("cleanalbum: %s " % cleanalbum)
     logger.debug ("cleanartist: %s " % cleanartist)
 

--- a/headphones/searcher.py
+++ b/headphones/searcher.py
@@ -1186,6 +1186,10 @@ def verifyresult(title, artistterm, term, lossless):
 
     return True
 
+def replace_all(text, dic):
+    for i, j in dic.iteritems():
+        text = text.replace(i, j)
+    return text
 
 def searchTorrent(album, new=False, losslessOnly=False, albumlength=None,
                   choose_specific_download=False):
@@ -1198,13 +1202,19 @@ def searchTorrent(album, new=False, losslessOnly=False, albumlength=None,
     year = get_year_from_release_date(reldate)
 
     # MERGE THIS WITH THE TERM CLEANUP FROM searchNZB
-    dic = {'...': '', ' & ': ' ', ' = ': ' ', '?': '', '$': 's', ' + ': ' ', '"': '', ',': ' ',
-           '*': ''}
+    dic = {'...': '', ' & ': ' ', ' = ': ' ', '?': '', '$': 's', ' + ': ' ', '"': '', ',': ' ','*': '', '+':' '}
 
-    semi_cleanalbum = helpers.replace_all(album['AlbumTitle'], dic)
-    cleanalbum = helpers.latinToAscii(semi_cleanalbum)
-    semi_cleanartist = helpers.replace_all(album['ArtistName'], dic)
+    semi_cleanalbum = replace_all(album['AlbumTitle'], dic)
+    semi_cleanartist = replace_all(album['ArtistName'], dic)
+	
     cleanartist = helpers.latinToAscii(semi_cleanartist)
+    cleanartist = re.sub('[\.\-\/]', ' ', cleanartist).encode('utf-8', 'replace')
+	
+    cleanalbum = helpers.latinToAscii(semi_cleanalbum)
+    cleanalbum = re.sub('[\.\-\/]', ' ', cleanalbum).encode('utf-8', 'replace')
+		
+    logger.debug ("cleanalbum: %s " % cleanalbum)
+    logger.debug ("cleanartist: %s " % cleanartist)
 
     # Use provided term if available, otherwise build our own (this code needs to be cleaned up since a lot
     # of these torrent providers are just using cleanartist/cleanalbum terms

--- a/headphones/searcher.py
+++ b/headphones/searcher.py
@@ -1204,7 +1204,7 @@ def searchTorrent(album, new=False, losslessOnly=False, albumlength=None,
     year = get_year_from_release_date(reldate)
 
     # MERGE THIS WITH THE TERM CLEANUP FROM searchNZB
-    dic = {'...': '', ' & ': ' ', ' = ': ' ', '?': '', '$': 's', ' + ': ' ', '"': '', ',': ' ','*': '', '+':' '}
+    dic = {'...': '', ' & ': ' ', ' = ': ' ', '?': '', '$': 's', ' + ': ' ', '"': '', ',': ' ', '*': '', '+': ' '}
 
     semi_cleanalbum = replace_all(album['AlbumTitle'], dic)
     semi_cleanartist = replace_all(album['ArtistName'], dic)
@@ -1214,9 +1214,9 @@ def searchTorrent(album, new=False, losslessOnly=False, albumlength=None,
 
     cleanalbum = helpers.latinToAscii(semi_cleanalbum)
     cleanalbum = re.sub('[\.\-\/]', ' ', cleanalbum).encode('utf-8', 'replace')
-	
-    logger.debug ("cleanalbum: %s " % cleanalbum)
-    logger.debug ("cleanartist: %s " % cleanartist)
+
+    logger.debug("cleanalbum: %s " % cleanalbum)
+    logger.debug("cleanartist: %s " % cleanartist)
 
     # Use provided term if available, otherwise build our own (this code needs to be cleaned up since a lot
     # of these torrent providers are just using cleanartist/cleanalbum terms


### PR DESCRIPTION
helper.replace_all doesn't seem to be working so album / artists with the special characters as per "dic" were not getting stripped, causing searches with jackett to fail.

I put in replace_all (lines 1189-1192) and changed the call to this. Also put a couple of debug lines in to monitor it works ok (1216,1217) and put in the re.sub for utf-8 encoding (it didn't seem to be in use with semi_clean_artist_term / semi_clean_album_term on lines 1243 and 1244