### PR TITLE
Add ability to skip path checks if Deluge host and Headphones host differ

### DIFF
--- a/data/interfaces/default/config.html
+++ b/data/interfaces/default/config.html
@@ -1605,6 +1605,12 @@
                                         <input type="checkbox" name="idtag" value="1" ${config['idtag']}>
                                     </label>
                                 </div>
+                                <div class="row checkbox left clearfix">
+                                    <label title="Deluge torrent client is on different device (Do not use foreign 'move after completion')">
+                                        Deluge torrent client is on different device
+                                        <input type="checkbox" name="deluge_foreign" value="1" ${config['deluge_foreign']}>
+                                    </label>
+                                </div>
                                 <div class="row">
                                     <label>Folder Permissions</label>
                                     <input type="text" name="folder_permissions" value="${config['folder_permissions']}" size="7">

--- a/headphones/config.py
+++ b/headphones/config.py
@@ -76,6 +76,7 @@ _CONFIG_DEFINITIONS = {
     'DELETE_LOSSLESS_FILES': (int, 'General', 1),
     'DELUGE_HOST': (str, 'Deluge', ''),
     'DELUGE_CERT': (str, 'Deluge', ''),
+    'DELUGE_FOREIGN': (int, 'Deluge', 0),
     'DELUGE_PASSWORD': (str, 'Deluge', ''),
     'DELUGE_LABEL': (str, 'Deluge', ''),
     'DELUGE_DONE_DIRECTORY': (str, 'Deluge', ''),

--- a/headphones/deluge.py
+++ b/headphones/deluge.py
@@ -603,15 +603,16 @@ def setTorrentPath(result):
             else:
                 move_to = headphones.CONFIG.DOWNLOAD_TORRENT_DIR
 
-            if not headphones.CONFIG.DELUGE_FOREIGN:
+            # If Deluge host is remote, disable path checks for now
+            if headphones.CONFIG.DELUGE_FOREIGN != 1:
                 if not os.path.exists(move_to):
                     logger.debug('Deluge: %s directory doesn\'t exist, let\'s create it' % move_to)
                     os.makedirs(move_to)
-                post_data = json.dumps({"method": "core.set_torrent_move_completed_path",
-                                        "params": [result['hash'], move_to],
-                                        "id": 8})
-                response = requests.post(delugeweb_url, data=post_data.encode('utf-8'), cookies=delugeweb_auth,
-                    verify=deluge_verify_cert, headers=headers)
+            post_data = json.dumps({"method": "core.set_torrent_move_completed_path",
+                                    "params": [result['hash'], move_to],
+                                    "id": 8})
+            response = requests.post(delugeweb_url, data=post_data.encode('utf-8'), cookies=delugeweb_auth,
+                verify=deluge_verify_cert, headers=headers)
 
             return not json.loads(response.text)['error']
 

--- a/headphones/deluge.py
+++ b/headphones/deluge.py
@@ -603,14 +603,15 @@ def setTorrentPath(result):
             else:
                 move_to = headphones.CONFIG.DOWNLOAD_TORRENT_DIR
 
-            if not os.path.exists(move_to):
-                logger.debug('Deluge: %s directory doesn\'t exist, let\'s create it' % move_to)
-                os.makedirs(move_to)
-            post_data = json.dumps({"method": "core.set_torrent_move_completed_path",
-                                    "params": [result['hash'], move_to],
-                                    "id": 8})
-            response = requests.post(delugeweb_url, data=post_data.encode('utf-8'), cookies=delugeweb_auth,
-                verify=deluge_verify_cert, headers=headers)
+            if not headphones.CONFIG.DELUGE_FOREIGN:
+                if not os.path.exists(move_to):
+                    logger.debug('Deluge: %s directory doesn\'t exist, let\'s create it' % move_to)
+                    os.makedirs(move_to)
+                post_data = json.dumps({"method": "core.set_torrent_move_completed_path",
+                                        "params": [result['hash'], move_to],
+                                        "id": 8})
+                response = requests.post(delugeweb_url, data=post_data.encode('utf-8'), cookies=delugeweb_auth,
+                    verify=deluge_verify_cert, headers=headers)
 
             return not json.loads(response.text)['error']
 

--- a/headphones/postprocessor.py
+++ b/headphones/postprocessor.py
@@ -46,10 +46,12 @@ def checkFolder():
             if album['FolderName']:
                 folder_name = album['FolderName']
                 single = False
+                # If not a torrent, use the default download directory
                 if album['Kind'] == 'nzb':
                     download_dir = headphones.CONFIG.DOWNLOAD_DIR
                 else:
-                    if headphones.CONFIG.DELUGE_DONE_DIRECTORY and headphones.CONFIG.TORRENT_DOWNLOADER == 3:
+                    # If Deluge 'Move after done' directory set and Deluge is in use
+                    if headphones.CONFIG.DELUGE_DONE_DIRECTORY and headphones.CONFIG.TORRENT_DOWNLOADER == 3 and headphones.CONFIG.DELUGE_FOREIGN != 1:
                         download_dir = headphones.CONFIG.DELUGE_DONE_DIRECTORY
                     else:
                         download_dir = headphones.CONFIG.DOWNLOAD_TORRENT_DIR

--- a/headphones/postprocessor.py
+++ b/headphones/postprocessor.py
@@ -50,7 +50,7 @@ def checkFolder():
                 if album['Kind'] == 'nzb':
                     download_dir = headphones.CONFIG.DOWNLOAD_DIR
                 else:
-                    # If Deluge 'Move after done' directory set and Deluge is in use
+                    # If Deluge 'Move after done' directory set, Deluge is in use and Deluge is not remote
                     if headphones.CONFIG.DELUGE_DONE_DIRECTORY and headphones.CONFIG.TORRENT_DOWNLOADER == 3 and headphones.CONFIG.DELUGE_FOREIGN != 1:
                         download_dir = headphones.CONFIG.DELUGE_DONE_DIRECTORY
                     else:

--- a/headphones/webserve.py
+++ b/headphones/webserve.py
@@ -1184,6 +1184,7 @@ class WebInterface(object):
             "transmission_password": headphones.CONFIG.TRANSMISSION_PASSWORD,
             "deluge_host": headphones.CONFIG.DELUGE_HOST,
             "deluge_cert": headphones.CONFIG.DELUGE_CERT,
+            "deluge_foreign": checked(headphones.CONFIG.DELUGE_FOREIGN),
             "deluge_password": headphones.CONFIG.DELUGE_PASSWORD,
             "deluge_label": headphones.CONFIG.DELUGE_LABEL,
             "deluge_done_directory": headphones.CONFIG.DELUGE_DONE_DIRECTORY,
@@ -1484,7 +1485,7 @@ class WebInterface(object):
             "songkick_enabled", "songkick_filter_enabled",
             "mpc_enabled", "email_enabled", "email_ssl", "email_tls", "email_onsnatch",
             "customauth", "idtag", "deluge_paused",
-            "join_enabled", "join_onsnatch"
+            "join_enabled", "join_onsnatch", "deluge_foreign"
         ]
         for checked_config in checked_configs:
             if checked_config not in kwargs:


### PR DESCRIPTION
This resolves the following scenario:

Deluge host, move destination wanted "/volume1/destination/movedest"

Headphones host, Deluge host mapped "/volume1/destination -> /mnt/deluge"

In this case the Headphones host must use headphones.CONFIG.DOWNLOAD_TORRENT_DIR for comparison rather than headphones.CONFIG.DELUGE_DONE_DIRECTORY otherwise it will be looking in /volume1/, a path which isn't mapped locally.  Temporarily, this patch just disables the path checks provided an advanced setting is enabled.

Fixes #3191 