### PR TITLE
redacted - add album type to search filter

### DIFF
--- a/headphones/searcher.py
+++ b/headphones/searcher.py
@@ -50,7 +50,6 @@ ruobj = None
 # Persistent RED API object
 redobj = None
 
-
 def fix_url(s, charset="utf-8"):
     """
     Fix the URL so it is proper formatted and encoded.
@@ -1206,6 +1205,37 @@ def searchTorrent(album, new=False, losslessOnly=False, albumlength=None,
     reldate = album['ReleaseDate']
 
     year = get_year_from_release_date(reldate)
+    
+    # Specify release types to filter by - used by Orpheus and Redacted
+    # Could be added to any Gazelle-based music tracker
+    album_type = ""
+    if album['Type'] == 'Album':
+        album_type = [gazellerelease_type.ALBUM]
+    if album['Type'] == 'Soundtrack':
+        album_type = [gazellerelease_type.SOUNDTRACK]
+    if album['Type'] == 'EP':
+        album_type = [gazellerelease_type.EP]
+    # No musicbrainz match for this type
+    # if album['Type'] == 'Anthology':
+    #   album_type = [gazellerelease_type.ANTHOLOGY]
+    if album['Type'] == 'Compilation':
+        album_type = [gazellerelease_type.COMPILATION]
+    if album['Type'] == 'DJ-mix':
+        album_type = [gazellerelease_type.DJ_MIX]
+    if album['Type'] == 'Single':
+        album_type = [gazellerelease_type.SINGLE]
+    if album['Type'] == 'Live':
+        album_type = [gazellerelease_type.LIVE_ALBUM]
+    if album['Type'] == 'Remix':
+        album_type = [gazellerelease_type.REMIX]
+    if album['Type'] == 'Bootleg':
+        album_type = [gazellerelease_type.BOOTLEG]
+    if album['Type'] == 'Interview':
+        album_type = [gazellerelease_type.INTERVIEW]
+    if album['Type'] == 'Mixtape/Street':
+        album_type = [gazellerelease_type.MIXTAPE]
+    if album['Type'] == 'Other':
+        album_type = [gazellerelease_type.UNKNOWN]
 
     # MERGE THIS WITH THE TERM CLEANUP FROM searchNZB
     dic = {'...': '', ' & ': ' ', ' = ': ' ', '?': '', '$': 's', ' + ': ' ', '"': '', ',': ' ',
@@ -1514,37 +1544,6 @@ def searchTorrent(album, new=False, losslessOnly=False, albumlength=None,
             logger.info(u"Searching %s..." % provider)
             all_torrents = []
 
-            album_type = ""
-
-            # Specify release types to filter by
-            if album['Type'] == 'Album':
-                album_type = [gazellerelease_type.ALBUM]
-            if album['Type'] == 'Soundtrack':
-                album_type = [gazellerelease_type.SOUNDTRACK]
-            if album['Type'] == 'EP':
-                album_type = [gazellerelease_type.EP]
-            # No musicbrainz match for this type
-            # if album['Type'] == 'Anthology':
-            #   album_type = [gazellerelease_type.ANTHOLOGY]
-            if album['Type'] == 'Compilation':
-                album_type = [gazellerelease_type.COMPILATION]
-            if album['Type'] == 'DJ-mix':
-                album_type = [gazellerelease_type.DJ_MIX]
-            if album['Type'] == 'Single':
-                album_type = [gazellerelease_type.SINGLE]
-            if album['Type'] == 'Live':
-                album_type = [gazellerelease_type.LIVE_ALBUM]
-            if album['Type'] == 'Remix':
-                album_type = [gazellerelease_type.REMIX]
-            if album['Type'] == 'Bootleg':
-                album_type = [gazellerelease_type.BOOTLEG]
-            if album['Type'] == 'Interview':
-                album_type = [gazellerelease_type.INTERVIEW]
-            if album['Type'] == 'Mixtape/Street':
-                album_type = [gazellerelease_type.MIXTAPE]
-            if album['Type'] == 'Other':
-                album_type = [gazellerelease_type.UNKNOWN]
-
             for search_format in search_formats:
                 if usersearchterm:
                     all_torrents.extend(
@@ -1644,16 +1643,18 @@ def searchTorrent(album, new=False, losslessOnly=False, albumlength=None,
         if redobj and redobj.logged_in():
             logger.info(u"Searching %s..." % provider)
             all_torrents = []
+
             for search_format in search_formats:
                 if usersearchterm:
                     all_torrents.extend(
                         redobj.search_torrents(searchstr=usersearchterm, format=search_format,
-                                                encoding=bitrate_string)['results'])
+                                                encoding=bitrate_string, releasetype=album_type)['results'])
                 else:
                     all_torrents.extend(redobj.search_torrents(artistname=semi_clean_artist_term,
                                                                 groupname=semi_clean_album_term,
                                                                 format=search_format,
-                                                                encoding=bitrate_string)['results'])
+                                                                encoding=bitrate_string,
+                                                                releasetype=album_type)['results'])
 
             # filter on format, size, and num seeders
             logger.info(u"Filtering torrents by format, maximum size, and minimum seeders...")

--- a/headphones/searcher.py
+++ b/headphones/searcher.py
@@ -50,6 +50,7 @@ ruobj = None
 # Persistent RED API object
 redobj = None
 
+
 def fix_url(s, charset="utf-8"):
     """
     Fix the URL so it is proper formatted and encoded.
@@ -1205,7 +1206,7 @@ def searchTorrent(album, new=False, losslessOnly=False, albumlength=None,
     reldate = album['ReleaseDate']
 
     year = get_year_from_release_date(reldate)
-    
+
     # Specify release types to filter by - used by Orpheus and Redacted
     # Could be added to any Gazelle-based music tracker
     album_type = ""


### PR DESCRIPTION
For Redacted - filter search results to only match album type - like Album, Single, EP, etc. 

Prevents mistakenly downloading the wrong release type where both have the same name. For example, a full album and a single. 

Same type of change  that was made in 914ab655772fdd893184ce1a147404035e95a9aa

Moved the album_type variable definition to the top of the searchTorrent function so it would be applied to both Redacted and Orpheus, instead of just applying to Orpheus. 