### PR TITLE
redacted and orpheus sort results by seeders

### DIFF
--- a/headphones/searcher.py
+++ b/headphones/searcher.py
@@ -436,7 +436,6 @@ def sort_search_results(resultlist, album, new, albumlength):
 
     resultlist = temp_list
 
-    # if headphones.CONFIG.PREFERRED_QUALITY == 2 and headphones.CONFIG.PREFERRED_BITRATE and result[3] != 'Orpheus.network':
     if headphones.CONFIG.PREFERRED_QUALITY == 2 and headphones.CONFIG.PREFERRED_BITRATE:
 
         try:
@@ -484,14 +483,15 @@ def sort_search_results(resultlist, album, new, albumlength):
 
         finallist = sorted(resultlist, key=lambda title: (title[5], int(title[1])), reverse=True)
 
-        # keep number of seeders order for Orpheus.network
-        # if result[3] == 'Orpheus.network':
-        #    finallist = resultlist
 
     if not len(finallist):
         logger.info('No appropriate matches found for %s - %s', album['ArtistName'],
                     album['AlbumTitle'])
         return None
+
+    if (result[3] == 'Orpheus.network') or (result[3] == 'Redacted'):
+        logger.info('NOTICE: setting finalist for proper order')
+        finallist = resultlist
 
     return finallist
 

--- a/headphones/searcher.py
+++ b/headphones/searcher.py
@@ -483,7 +483,6 @@ def sort_search_results(resultlist, album, new, albumlength):
 
         finallist = sorted(resultlist, key=lambda title: (title[5], int(title[1])), reverse=True)
 
-
     if not len(finallist):
         logger.info('No appropriate matches found for %s - %s', album['ArtistName'],
                     album['AlbumTitle'])

--- a/headphones/searcher.py
+++ b/headphones/searcher.py
@@ -490,7 +490,7 @@ def sort_search_results(resultlist, album, new, albumlength):
 
     if result[3]:
         if (result[3] == 'Orpheus.network') or (result[3] == 'Redacted'):
-            logger.info('Keeping torrent ordered by seeders for %s' % result[3])
+            logger.info('Keeping torrents ordered by seeders for %s' % result[3])
             finallist = resultlist
 
     return finallist

--- a/headphones/searcher.py
+++ b/headphones/searcher.py
@@ -488,9 +488,10 @@ def sort_search_results(resultlist, album, new, albumlength):
                     album['AlbumTitle'])
         return None
 
-    if (result[3] == 'Orpheus.network') or (result[3] == 'Redacted'):
-        logger.info('NOTICE: setting finalist for proper order')
-        finallist = resultlist
+    if result[3]:
+        if (result[3] == 'Orpheus.network') or (result[3] == 'Redacted'):
+            logger.info('Keeping torrent ordered by seeders for %s' % result[3])
+            finallist = resultlist
 
     return finallist
 


### PR DESCRIPTION
Sorts results by number of seeders and downloads the torrent with the most seeders. Fixes #3171 and improves upon 81486d2

This time I wrote a separate if statement that only takes effect if the provider **_is_** Redacted/Orpheus  which should hopefully clear up any conflicts. 

Cleaned up code from previous commit 81486d2.