### PR TITLE
Fixes for Python 3.10

### DIFF
--- a/headphones/deluge.py
+++ b/headphones/deluge.py
@@ -472,32 +472,13 @@ def _add_torrent_file(result):
         # content is torrent file contents that needs to be encoded to base64
         post_data = json.dumps({"method": "core.add_torrent_file",
                                 "params": [result['name'] + '.torrent',
-                                b64encode(result['content'].encode('utf8')), {}],
+                                b64encode(result['content']).decode(), {}],
                                 "id": 2})
         response = requests.post(delugeweb_url, data=post_data.encode('utf-8'), cookies=delugeweb_auth,
             verify=deluge_verify_cert, headers=headers)
         result['hash'] = json.loads(response.text)['result']
         logger.debug('Deluge: Response was %s' % str(json.loads(response.text)))
         return json.loads(response.text)['result']
-    except UnicodeDecodeError:
-        try:
-            # content is torrent file contents that needs to be encoded to base64
-            # this time let's try leaving the encoding as is
-            logger.debug('Deluge: There was a decoding issue, let\'s try again')
-            post_data = json.dumps({"method": "core.add_torrent_file",
-                                    "params": [result['name'].decode('utf8') + '.torrent',
-                                    b64encode(result['content']), {}],
-                                    "id": 22})
-            response = requests.post(delugeweb_url, data=post_data.encode('utf-8'), cookies=delugeweb_auth,
-                verify=deluge_verify_cert, headers=headers)
-            result['hash'] = json.loads(response.text)['result']
-            logger.debug('Deluge: Response was %s' % str(json.loads(response.text)))
-            return json.loads(response.text)['result']
-        except Exception as e:
-            logger.error('Deluge: Adding torrent file failed after decode: %s' % str(e))
-            formatted_lines = traceback.format_exc().splitlines()
-            logger.error('; '.join(formatted_lines))
-            return False
     except Exception as e:
         logger.error('Deluge: Adding torrent file failed: %s' % str(e))
         formatted_lines = traceback.format_exc().splitlines()

--- a/lib/apscheduler/job.py
+++ b/lib/apscheduler/job.py
@@ -1,4 +1,4 @@
-from collections import Iterable, Mapping
+from collections.abc import Iterable, Mapping
 from uuid import uuid4
 
 import six

--- a/lib/apscheduler/schedulers/base.py
+++ b/lib/apscheduler/schedulers/base.py
@@ -1,6 +1,6 @@
 
 from abc import ABCMeta, abstractmethod
-from collections import MutableMapping
+from collections.abc import MutableMapping
 from threading import RLock
 from datetime import datetime
 from logging import getLogger

--- a/lib/mutagen/apev2.py
+++ b/lib/mutagen/apev2.py
@@ -32,7 +32,7 @@ __all__ = ["APEv2", "APEv2File", "Open", "delete"]
 
 import sys
 import struct
-from collections import MutableSequence
+from collections.abc import MutableSequence
 
 from ._compat import (cBytesIO, PY3, text_type, PY2, reraise, swap_to_string,
                       xrange)

--- a/lib/pygazelle/api.py
+++ b/lib/pygazelle/api.py
@@ -5,7 +5,7 @@
 #
 # Loosely based on the API implementation from 'whatbetter', by Zachary Denton
 # See https://github.com/zacharydenton/whatbetter
-from html.parser import HTMLParser
+import html
 
 import sys
 import json
@@ -219,10 +219,10 @@ class GazelleAPI(object):
             else:
                 artist = Artist(id, self)
             if name:
-                artist.name = HTMLParser().unescape(name)
+                artist.name = html.unescape(name)
         elif name:
             artist = Artist(-1, self)
-            artist.name = HTMLParser().unescape(name)
+            artist.name = html.unescape(name)
         else:
             raise Exception("You must specify either an ID or a Name to get an artist.")
 

--- a/lib/pygazelle/artist.py
+++ b/lib/pygazelle/artist.py
@@ -1,4 +1,4 @@
-from html.parser import HTMLParser
+import html
 
 class InvalidArtistException(Exception):
     pass
@@ -29,7 +29,7 @@ class Artist(object):
         if self.id > 0:
             response = self.parent_api.request(action='artist', id=self.id)
         elif self.name:
-            self.name = HTMLParser().unescape(self.name)
+            self.name = html.unescape(self.name)
             try:
                 response = self.parent_api.request(action='artist', artistname=self.name)
             except Exception:
@@ -47,7 +47,7 @@ class Artist(object):
             self.id = artist_json_response['id']
             self.parent_api.cached_artists[self.id] = self
 
-        self.name = HTMLParser().unescape(artist_json_response['name'])
+        self.name = html.unescape(artist_json_response['name'])
         self.notifications_enabled = artist_json_response['notificationsEnabled']
         self.has_bookmarked = artist_json_response['hasBookmarked']
         self.image = artist_json_response['image']


### PR DESCRIPTION
Hi, I've been testing the latest develop branches with Python 3.10 (not sure which version is the target)
For now, I had to make the following changes to make things work with my config:

- deluge: b64encode returns bytes, transform into string before
  serializing to JSON.
- deluge: no more need to try different encodings for the torrent
  filename or the base64-encoded content, should all be unicode strings
  with Python 3
- collections.abc: Iterable, Mapping, MutableMapping moved from
  collections to collections.abc since Python 3.3
- pygazelle: html.parser.HTMLParser().unescape() moved to
  html.unescape() in Python 3.4