### PR TITLE
Gazelle improvements

### DIFF
--- a/data/interfaces/default/config.html
+++ b/data/interfaces/default/config.html
@@ -709,6 +709,10 @@
                                     </div>
                                     <div class="config">
                                         <div class="row">
+                                            <label>Api Key</label>
+                                            <input type="text" name="redacted_apikey" value="${config['redacted_apikey']}" size="36">
+                                        </div>
+                                        <div class="row">
                                             <label>Username</label>
                                             <input type="text" name="redacted_username" value="${config['redacted_username']}" size="36">
                                         </div>

--- a/headphones/config.py
+++ b/headphones/config.py
@@ -306,6 +306,7 @@ _CONFIG_DEFINITIONS = {
     'VERIFY_SSL_CERT': (bool_int, 'Advanced', 1),
     'WAIT_UNTIL_RELEASE_DATE': (int, 'General', 0),
     'REDACTED': (int, 'Redacted', 0),
+    'REDACTED_APIKEY': (str, 'Redacted', ''),
     'REDACTED_USERNAME': (str, 'Redacted', ''),
     'REDACTED_PASSWORD': (str, 'Redacted', ''),
     'REDACTED_RATIO': (str, 'Redacted', ''),

--- a/headphones/searcher.py
+++ b/headphones/searcher.py
@@ -1662,25 +1662,22 @@ def searchTorrent(album, new=False, losslessOnly=False, albumlength=None,
             logger.info(
                 "Remaining torrents: %s" % ", ".join(repr(torrent) for torrent in match_torrents))
 
-            # sort by times d/l'd
+            # Sort by quality and seeders
             if not len(match_torrents):
                 logger.info("No results found from %s for %s after filtering" % (provider, term))
             elif len(match_torrents) > 1:
                 logger.info("Found %d matching releases from %s for %s - %s after filtering" %
                             (len(match_torrents), provider, artistterm, albumterm))
-                logger.info('Sorting torrents by number of seeders...')
-                match_torrents.sort(key=lambda x: int(x.seeders), reverse=True)
-                if gazelleformat.MP3 in search_formats:
-                    logger.info('Sorting torrents by seeders...')
-                    match_torrents.sort(key=lambda x: int(x.seeders), reverse=True)
                 if search_formats and None not in search_formats:
-                    match_torrents.sort(
-                        key=lambda x: int(search_formats.index(x.format)))  # prefer lossless
-                #                if bitrate:
-                #                    match_torrents.sort(key=lambda x: re.match("mp3", x.getTorrentDetails(), flags=re.I), reverse=True)
-                #                    match_torrents.sort(key=lambda x: str(bitrate) in x.getTorrentFolderName(), reverse=True)
+                    logger.info('Sorting torrents by format and number of seeders...')
+                    match_torrents.sort(key=lambda x: (search_formats.index(x.format), -int(x.seeders)))
+                else:
+                    logger.info('Sorting torrents by number of seeders...')
+                    match_torrents.sort(key=lambda x: int(x.seeders), reverse=True)
                 logger.info(
-                    "New order: %s" % ", ".join(repr(torrent) for torrent in match_torrents))
+                    "New order: %s" %
+                    ", ".join(repr(torrent) for torrent in match_torrents)
+                )
 
             results = []
             for torrent in match_torrents:

--- a/headphones/searcher.py
+++ b/headphones/searcher.py
@@ -1590,9 +1590,9 @@ def searchTorrent(album, new=False, losslessOnly=False, albumlength=None,
         if not orpheusobj or not orpheusobj.logged_in():
             try:
                 logger.info("Attempting to log in to Orpheus.network...")
-                orpheusobj = gazelleapi.GazelleAPI(headphones.CONFIG.ORPHEUS_USERNAME,
-                                                headphones.CONFIG.ORPHEUS_PASSWORD,
-                                                headphones.CONFIG.ORPHEUS_URL)
+                orpheusobj = gazelleapi.GazelleAPI(username=headphones.CONFIG.ORPHEUS_USERNAME,
+                                                password=headphones.CONFIG.ORPHEUS_PASSWORD,
+                                                url=headphones.CONFIG.ORPHEUS_URL)
                 orpheusobj._login()
             except Exception as e:
                 orpheusobj = None
@@ -1726,9 +1726,8 @@ def searchTorrent(album, new=False, losslessOnly=False, albumlength=None,
         if not redobj or not redobj.logged_in():
             try:
                 logger.info("Attempting to log in to Redacted...")
-                redobj = gazelleapi.GazelleAPI(headphones.CONFIG.REDACTED_USERNAME,
-                                                headphones.CONFIG.REDACTED_PASSWORD,
-                                                providerurl)
+                redobj = gazelleapi.GazelleAPI(apikey=headphones.CONFIG.REDACTED_APIKEY,
+                                                url=providerurl)
                 redobj._login()
             except Exception as e:
                 redobj = None

--- a/headphones/webserve.py
+++ b/headphones/webserve.py
@@ -1242,6 +1242,7 @@ class WebInterface(object):
             "orpheus_ratio": headphones.CONFIG.ORPHEUS_RATIO,
             "orpheus_url": headphones.CONFIG.ORPHEUS_URL,
             "use_redacted": checked(headphones.CONFIG.REDACTED),
+            "redacted_apikey": headphones.CONFIG.REDACTED_APIKEY,
             "redacted_username": headphones.CONFIG.REDACTED_USERNAME,
             "redacted_password": headphones.CONFIG.REDACTED_PASSWORD,
             "redacted_ratio": headphones.CONFIG.REDACTED_RATIO,

--- a/lib/pygazelle/api.py
+++ b/lib/pygazelle/api.py
@@ -41,11 +41,12 @@ class GazelleAPI(object):
         'Accept-Charset': 'ISO-8859-1,utf-8;q=0.7,*;q=0.3'}
 
 
-    def __init__(self, username=None, password=None, url=None):
+    def __init__(self, apikey=None, username=None, password=None, url=None):
         self.session = requests.session()
         self.session.headers = self.default_headers
         self.username = username
         self.password = password
+        self.apikey = apikey
         self.authkey = None
         self.passkey = None
         self.userid = None
@@ -94,14 +95,17 @@ class GazelleAPI(object):
 
         self.wait_for_rate_limit()
 
-        loginpage = self.site + 'login.php'
-        data = {'username': self.username,
-                'password': self.password,
-                'keeplogged': '1'}
-        r = self.session.post(loginpage, data=data, timeout=self.default_timeout, headers=self.default_headers)
-        self.past_request_timestamps.append(time.time())
-        if r.status_code != 200:
-            raise LoginException("Login returned status code %s" % r.status_code)
+        if self.apikey is not None:
+            self.session.headers["Authorization"] = self.apikey
+        else:
+            loginpage = self.site + 'login.php'
+            data = {'username': self.username,
+                    'password': self.password,
+                    'keeplogged': '1'}
+            r = self.session.post(loginpage, data=data, timeout=self.default_timeout, headers=self.default_headers)
+            self.past_request_timestamps.append(time.time())
+            if r.status_code != 200:
+                raise LoginException("Login returned status code %s" % r.status_code)
 
         try:
             accountinfo = self.request('index', autologin=False)


### PR DESCRIPTION
Several improvements:
- update redacted url
- add (optional) apikey sign-in to redacted instead of username/password (allows to enable 2FA sign-in)
- merge code for Orpheus & Redacted (same code, except for album_type filtering, which was only implemented in Orpheus code and is now available also for Redacted)
- simplify sorting code (only 2 options instead of multiple redundant sorts)