### PR TITLE
Fix Syntax Errors with Python 3.12

### DIFF
--- a/lib/gntp/core.py
+++ b/lib/gntp/core.py
@@ -19,18 +19,18 @@ __all__ = [
 
 #GNTP/<version> <messagetype> <encryptionAlgorithmID>[:<ivValue>][ <keyHashAlgorithmID>:<keyHash>.<salt>]
 GNTP_INFO_LINE = re.compile(
-	'GNTP/(?P<version>\d+\.\d+) (?P<messagetype>REGISTER|NOTIFY|SUBSCRIBE|\-OK|\-ERROR)' +
+	'GNTP/(?P<version>\\d+\\.\\d+) (?P<messagetype>REGISTER|NOTIFY|SUBSCRIBE|\\-OK|\\-ERROR)' +
 	' (?P<encryptionAlgorithmID>[A-Z0-9]+(:(?P<ivValue>[A-F0-9]+))?) ?' +
 	'((?P<keyHashAlgorithmID>[A-Z0-9]+):(?P<keyHash>[A-F0-9]+).(?P<salt>[A-F0-9]+))?\r\n',
 	re.IGNORECASE
 )
 
 GNTP_INFO_LINE_SHORT = re.compile(
-	'GNTP/(?P<version>\d+\.\d+) (?P<messagetype>REGISTER|NOTIFY|SUBSCRIBE|\-OK|\-ERROR)',
+	'GNTP/(?P<version>\\d+\\.\\d+) (?P<messagetype>REGISTER|NOTIFY|SUBSCRIBE|\\-OK|\\-ERROR)',
 	re.IGNORECASE
 )
 
-GNTP_HEADER = re.compile('([\w-]+):(.+)')
+GNTP_HEADER = re.compile('([\\w-]+):(.+)')
 
 GNTP_EOL = gntp.shim.b('\r\n')
 GNTP_SEP = gntp.shim.b(': ')

--- a/lib/gntp/core.py
+++ b/lib/gntp/core.py
@@ -19,18 +19,18 @@ __all__ = [
 
 #GNTP/<version> <messagetype> <encryptionAlgorithmID>[:<ivValue>][ <keyHashAlgorithmID>:<keyHash>.<salt>]
 GNTP_INFO_LINE = re.compile(
-	'GNTP/(?P<version>\d+\.\d+) (?P<messagetype>REGISTER|NOTIFY|SUBSCRIBE|\-OK|\-ERROR)' +
+	r'GNTP/(?P<version>\d+\.\d+) (?P<messagetype>REGISTER|NOTIFY|SUBSCRIBE|\-OK|\-ERROR)' +
 	' (?P<encryptionAlgorithmID>[A-Z0-9]+(:(?P<ivValue>[A-F0-9]+))?) ?' +
 	'((?P<keyHashAlgorithmID>[A-Z0-9]+):(?P<keyHash>[A-F0-9]+).(?P<salt>[A-F0-9]+))?\r\n',
 	re.IGNORECASE
 )
 
 GNTP_INFO_LINE_SHORT = re.compile(
-	'GNTP/(?P<version>\d+\.\d+) (?P<messagetype>REGISTER|NOTIFY|SUBSCRIBE|\-OK|\-ERROR)',
+	r'GNTP/(?P<version>\d+\.\d+) (?P<messagetype>REGISTER|NOTIFY|SUBSCRIBE|\-OK|\-ERROR)',
 	re.IGNORECASE
 )
 
-GNTP_HEADER = re.compile('([\w-]+):(.+)')
+GNTP_HEADER = re.compile(r'([\w-]+):(.+)')
 
 GNTP_EOL = gntp.shim.b('\r\n')
 GNTP_SEP = gntp.shim.b(': ')

--- a/lib/gntp/core.py
+++ b/lib/gntp/core.py
@@ -19,18 +19,18 @@ __all__ = [
 
 #GNTP/<version> <messagetype> <encryptionAlgorithmID>[:<ivValue>][ <keyHashAlgorithmID>:<keyHash>.<salt>]
 GNTP_INFO_LINE = re.compile(
-	'GNTP/(?P<version>\\d+\\.\\d+) (?P<messagetype>REGISTER|NOTIFY|SUBSCRIBE|\\-OK|\\-ERROR)' +
+	'GNTP/(?P<version>\d+\.\d+) (?P<messagetype>REGISTER|NOTIFY|SUBSCRIBE|\-OK|\-ERROR)' +
 	' (?P<encryptionAlgorithmID>[A-Z0-9]+(:(?P<ivValue>[A-F0-9]+))?) ?' +
 	'((?P<keyHashAlgorithmID>[A-Z0-9]+):(?P<keyHash>[A-F0-9]+).(?P<salt>[A-F0-9]+))?\r\n',
 	re.IGNORECASE
 )
 
 GNTP_INFO_LINE_SHORT = re.compile(
-	'GNTP/(?P<version>\\d+\\.\\d+) (?P<messagetype>REGISTER|NOTIFY|SUBSCRIBE|\\-OK|\\-ERROR)',
+	'GNTP/(?P<version>\d+\.\d+) (?P<messagetype>REGISTER|NOTIFY|SUBSCRIBE|\-OK|\-ERROR)',
 	re.IGNORECASE
 )
 
-GNTP_HEADER = re.compile('([\\w-]+):(.+)')
+GNTP_HEADER = re.compile('([\w-]+):(.+)')
 
 GNTP_EOL = gntp.shim.b('\r\n')
 GNTP_SEP = gntp.shim.b(': ')


### PR DESCRIPTION
When running Headphones with Python 3.12 on Synology the following syntax errors were noted:

```
Starting headphones command /volume1/@appstore/headphones/env/bin/python3 /volume1/@appstore/headphones/share/Headphones/Headphones.py --daemon --pidfile /volume1/@appdata/headphones/headphones.pid --config /volume1/@appdata/headphones/config.ini --datadir /volume1/@appdata/headphones/
/volume1/@appstore/headphones/share/Headphones/lib/gntp/core.py:22: SyntaxWarning: invalid escape sequence '\d'
  'GNTP/(?P<version>\d+\.\d+) (?P<messagetype>REGISTER|NOTIFY|SUBSCRIBE|\-OK|\-ERROR)' +
/volume1/@appstore/headphones/share/Headphones/lib/gntp/core.py:29: SyntaxWarning: invalid escape sequence '\d'
  'GNTP/(?P<version>\d+\.\d+) (?P<messagetype>REGISTER|NOTIFY|SUBSCRIBE|\-OK|\-ERROR)',
/volume1/@appstore/headphones/share/Headphones/lib/gntp/core.py:33: SyntaxWarning: invalid escape sequence '\w'
  GNTP_HEADER = re.compile('([\w-]+):(.+)')
```

This PR fixes the escaping of `\` characters which resolves the errors seen above.