### PR TITLE
fix: handle missing next_sibling in torznab link element

### DIFF
--- a/headphones/searcher.py
+++ b/headphones/searcher.py
@@ -1479,8 +1479,9 @@ def searchTorrent(album, new=False, losslessOnly=False, albumlength=None,
                     for item in items:
                         try:
                             title = item.title.get_text()
-                            if item.find("link"):
-                                url = item.find("link").next_sibling.strip()
+                            link_element = item.find("link")
+                            if link_element and link_element.next_sibling:
+                                url = link_element.next_sibling.strip()
                             else:
                                 url = item.find('enclosure').get('url')
                             seeders = int(item.find("torznab:attr", attrs={"name": "seeders"}).get('value'))


### PR DESCRIPTION
## Summary
- Fixes parsing error when torznab providers return link elements without text content
- Adds proper null checks before accessing next_sibling attribute
- Falls back to enclosure element URL as per torznab specification

## Problem
When using torznab providers like Bitmagnet that return link elements without text content (next_sibling), the code crashes with:
```
AttributeError: 'NoneType' object has no attribute 'next_sibling'
```

This occurs at line 1483 in searcher.py when attempting to call `.next_sibling.strip()` on a link element that doesn't have a next sibling.

## Solution
Updated the link parsing logic to:
1. Store the link element in a variable to avoid calling `find()` twice
2. Check that both the link element exists AND has a next_sibling before accessing it
3. Fall back to the enclosure element's URL if either condition fails

This follows the torznab specification which allows link information in the enclosure element.

## Testing
The fix ensures that:
- Torznab providers with standard link format continue to work
- Providers like Bitmagnet that use enclosure elements work correctly
- No AttributeError is raised when link elements lack next_sibling

Fixes #3347